### PR TITLE
Add scaffold compilation test and symbol verification CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,8 @@ jobs:
         run: cargo build --manifest-path examples/hello-ext/Cargo.toml --release
       - name: Verify extension entry point symbol
         run: |
-          SO=$(find examples/hello-ext/target/release -name '*.so' -o -name '*.dylib' | head -1)
-          if [ -z "$SO" ]; then echo "No .so/.dylib found"; exit 1; fi
+          SO=$(find examples/hello-ext/target/release -maxdepth 1 -name 'libhello_ext.so' -o -name 'libhello_ext.dylib' | head -1)
+          if [ -z "$SO" ]; then echo "No libhello_ext.so/.dylib found"; exit 1; fi
           nm -D "$SO" | grep -q 'T hello_ext_init_c_api' || {
             echo "ERROR: entry point symbol hello_ext_init_c_api not found in $SO"
             nm -D "$SO" | head -20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,36 @@ jobs:
       - run: cargo clippy --manifest-path examples/hello-ext/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path examples/hello-ext/Cargo.toml
 
+  scaffold-compile:
+    name: Scaffold (compile check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - name: Verify scaffold output compiles
+        run: cargo test scaffold_generated_code_compiles -- --nocapture
+
+  symbol-check:
+    name: Symbol check (hello-ext)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - name: Build hello-ext as cdylib
+        run: cargo build --manifest-path examples/hello-ext/Cargo.toml --release
+      - name: Verify extension entry point symbol
+        run: |
+          SO=$(find examples/hello-ext/target/release -name '*.so' -o -name '*.dylib' | head -1)
+          if [ -z "$SO" ]; then echo "No .so/.dylib found"; exit 1; fi
+          nm -D "$SO" | grep -q 'T hello_ext_init_c_api' || {
+            echo "ERROR: entry point symbol hello_ext_init_c_api not found in $SO"
+            nm -D "$SO" | head -20
+            exit 1
+          }
+          echo "Found hello_ext_init_c_api in $SO"
+
   security:
     name: Security (cargo-deny)
     runs-on: ubuntu-latest

--- a/src/scaffold/mod.rs
+++ b/src/scaffold/mod.rs
@@ -232,7 +232,7 @@ fn register(con: libduckdb_sys::duckdb_connection) -> Result<(), ExtensionError>
 // Entry point — the C Extension API handles everything, no C++ glue needed.
 // ---------------------------------------------------------------------------
 
-entry_point!({name}_init_c_api, |con| register(con));
+quack_rs::entry_point!({name}_init_c_api, |con| register(con));
 "#,
         description = config.description,
         name = config.name,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -508,3 +508,75 @@ fn sql_macro_error_mentions_bad_param_name() {
     let err = SqlMacro::scalar("f", &["Bad"], "1").unwrap_err();
     assert!(err.as_str().contains("Bad"));
 }
+
+// ---------------------------------------------------------------------------
+// TEST-2: Scaffold generated code compiles successfully
+// ---------------------------------------------------------------------------
+
+/// Generates scaffold files, writes them to a temp directory with a path-dep
+/// on the local quack-rs crate, and runs `cargo check` to verify the generated
+/// code actually compiles.  This catches template regressions (like broken
+/// macro paths) that unit tests can't detect.
+#[test]
+fn scaffold_generated_code_compiles() {
+    use quack_rs::scaffold::{generate_scaffold, ScaffoldConfig};
+    use std::fs;
+    use std::process::Command;
+
+    let config = ScaffoldConfig {
+        name: "test_ext".to_string(),
+        description: "Scaffold compile test".to_string(),
+        version: "0.1.0".to_string(),
+        license: "MIT".to_string(),
+        maintainer: "CI".to_string(),
+        github_repo: "test/test-ext".to_string(),
+        excluded_platforms: vec![],
+    };
+
+    let files = generate_scaffold(&config).unwrap();
+
+    // Write to a temp directory
+    let tmp = std::env::temp_dir().join("quack_rs_scaffold_compile_test");
+    let _ = fs::remove_dir_all(&tmp);
+    fs::create_dir_all(tmp.join("src")).unwrap();
+
+    // The scaffold Cargo.toml references `quack-rs = "0.2"` from crates.io.
+    // Replace it with a path dependency pointing to this workspace root so
+    // `cargo check` uses the local (possibly-modified) crate.
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    for f in &files {
+        let dest = tmp.join(&f.path);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+
+        if f.path == "Cargo.toml" {
+            // Rewrite quack-rs dep to use local path
+            let patched = f.content.replace(
+                r#"quack-rs = { version = "0.2" }"#,
+                &format!("quack-rs = {{ path = \"{}\" }}", workspace_root.display()),
+            );
+            fs::write(&dest, patched).unwrap();
+        } else {
+            fs::write(&dest, &f.content).unwrap();
+        }
+    }
+
+    // Run cargo check on the generated project
+    let output = Command::new("cargo")
+        .args(["check", "--lib"])
+        .current_dir(&tmp)
+        .output()
+        .expect("failed to run cargo check");
+
+    // Clean up before asserting so we don't leave temp dirs on failure
+    let _ = fs::remove_dir_all(&tmp);
+
+    assert!(
+        output.status.success(),
+        "Scaffold-generated code failed to compile!\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -555,7 +555,10 @@ fn scaffold_generated_code_compiles() {
             // Rewrite quack-rs dep to use local path
             let patched = f.content.replace(
                 r#"quack-rs = { version = "0.2" }"#,
-                &format!("quack-rs = {{ path = \"{}\" }}", workspace_root.display()),
+                &format!(
+                    "quack-rs = {{ path = \"{}\" }}",
+                    workspace_root.display().to_string().replace('\\', "/")
+                ),
             );
             fs::write(&dest, patched).unwrap();
         } else {


### PR DESCRIPTION
## Summary

This PR adds two new CI checks to catch regressions in the scaffold code generation:

1. **Scaffold compilation test**: A new integration test that generates scaffold files, writes them to a temp directory with a path dependency on the local quack-rs crate, and runs `cargo check` to verify the generated code compiles. This catches template regressions (like broken macro paths) that unit tests can't detect.

2. **Symbol verification**: A new CI job that builds the hello-ext example as a cdylib and verifies the required entry point symbol `hello_ext_init_c_api` is present in the compiled shared library.

Additionally, fixes a bug in the scaffold template where the `entry_point!` macro invocation was missing the `quack_rs::` namespace prefix, which would cause generated extensions to fail compilation.

## Type of change

- [x] Bug fix (non-breaking, fixes a specific issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [x] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Checklist

### Code quality
- [x] `cargo test --all-targets` passes (new test included)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt` applied (no diff)
- [x] `cargo doc --no-deps` builds without warnings
- [x] All `unsafe` blocks have a `// SAFETY:` comment (N/A)

### Documentation
- [x] Public API changes are documented in rustdoc (N/A)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (user-facing bug fix in scaffold)
- [ ] Book (`book/src/`) updated if the change affects extension authors (N/A)
- [ ] New FFI pitfall discovered → added to `LESSONS.md` and `book/src/reference/pitfalls.md` (N/A)

### Safety (for changes touching `unsafe`)
- [x] No new panics introduced in FFI callback paths (N/A)
- [x] No new paths that could cross the FFI boundary with an unwinding panic (N/A)
- [x] `#![deny(unsafe_op_in_unsafe_fn)]` remains satisfied (N/A)

## Test Plan

The new `scaffold_generated_code_compiles` integration test is automatically run as part of the test suite and verifies that generated scaffold code compiles successfully. The new CI jobs (`scaffold-compile` and `symbol-check`) run on every push and verify both compilation and symbol presence in the built extension.

https://claude.ai/code/session_01GBpzpPJ1jCXDaMxvK1sX53