### PR TITLE
Update GitHub Actions dependencies to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,12 +222,12 @@ jobs:
       # SLSA Level 2 build provenance — creates a signed attestation linking
       # the .crate artifact to this workflow run, verifiable with `gh attestation verify`.
       - name: Attest build provenance (SLSA)
-        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: target/package/*.crate
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9ce0b178 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-artifacts
           path: |
@@ -264,7 +264,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download release artifacts
-        uses: actions/download-artifact@cc203385981b70ca67c1cc2e0571f2cb2f0c5082 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-artifacts
           path: release-artifacts/


### PR DESCRIPTION
## Summary

This PR updates three GitHub Actions workflow dependencies to their latest versions:
- `actions/attest-build-provenance` from v4 to v4.1.0
- `actions/upload-artifact` from v4 to v4.6.2
- `actions/download-artifact` from v4 to v4.3.0

These updates ensure the release workflow uses the latest bug fixes and improvements from the GitHub Actions ecosystem.

## Type of change

- [ ] Bug fix (non-breaking, fixes a specific issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [x] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Checklist

### Code quality
- [x] No code changes to test
- [x] No clippy/fmt changes needed
- [x] No documentation changes needed

### Testing
No testing needed — these are workflow dependency updates with no impact on source code or build artifacts.

https://claude.ai/code/session_012T2gBYDarpADmV68zezDbn