### PR TITLE
Make release workflow idempotent for GitHub and crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
           ls -lh release-artifacts/
           echo "::endgroup::"
 
-      - name: Create GitHub release
+      - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -309,21 +309,42 @@ jobs:
           VERSION="${{ needs.validate.outputs.version }}"
           IS_PRE="${{ needs.validate.outputs.is_prerelease }}"
           CRATE="${{ needs.validate.outputs.crate_name }}"
+          TAG="v${VERSION}"
 
           PRE_FLAG=""
           [[ "$IS_PRE" == "true" ]] && PRE_FLAG="--prerelease"
 
-          echo "::group::Creating GitHub release v$VERSION"
-          gh release create "v${VERSION}" \
-            $PRE_FLAG \
-            --title "${CRATE} v${VERSION}" \
-            --notes-file release_notes.md \
-            release-artifacts/*.crate \
-            release-artifacts/SHA256SUMS
-          echo "::endgroup::"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${TAG}"
 
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
-          echo "::notice::GitHub release created: $RELEASE_URL"
+          # Idempotent: if a release already exists (e.g. created by GitHub
+          # Desktop or the web UI when pushing a tag), update it in place
+          # instead of failing.
+          if gh release view "$TAG" &>/dev/null; then
+            echo "::warning::Release ${TAG} already exists — updating it."
+            echo "::group::Updating GitHub release ${TAG}"
+            gh release edit "$TAG" \
+              $PRE_FLAG \
+              --title "${CRATE} ${TAG}" \
+              --notes-file release_notes.md
+
+            # Upload assets (--clobber overwrites if they already exist)
+            gh release upload "$TAG" \
+              --clobber \
+              release-artifacts/*.crate \
+              release-artifacts/SHA256SUMS
+            echo "::endgroup::"
+            echo "::notice::GitHub release updated: $RELEASE_URL"
+          else
+            echo "::group::Creating GitHub release ${TAG}"
+            gh release create "$TAG" \
+              $PRE_FLAG \
+              --title "${CRATE} ${TAG}" \
+              --notes-file release_notes.md \
+              release-artifacts/*.crate \
+              release-artifacts/SHA256SUMS
+            echo "::endgroup::"
+            echo "::notice::GitHub release created: $RELEASE_URL"
+          fi
 
           # ── Step summary ──────────────────────────────────────────────────
           {
@@ -371,7 +392,16 @@ jobs:
           CRATE="${{ needs.validate.outputs.crate_name }}"
 
           echo "::group::cargo publish — $CRATE v$VERSION"
-          cargo publish
+          # Idempotent: if a re-run publishes the same version that's
+          # already on crates.io, treat it as success rather than failing.
+          if ! cargo publish 2>&1 | tee /tmp/publish.log; then
+            if grep -q "already uploaded" /tmp/publish.log; then
+              echo "::warning::$CRATE v$VERSION is already published — skipping."
+            else
+              echo "::error::cargo publish failed"
+              exit 1
+            fi
+          fi
           echo "::endgroup::"
 
           CRATES_URL="https://crates.io/crates/${CRATE}/${VERSION}"


### PR DESCRIPTION
## Summary

This PR makes the release workflow idempotent by handling cases where a GitHub release or crates.io publication already exists. The workflow now checks if a release already exists (e.g., created manually via GitHub Desktop or the web UI) and updates it in place rather than failing. Similarly, when publishing to crates.io, if the version is already published, the workflow treats it as success instead of failing. This allows the release job to be safely re-run without manual intervention.

## Type of change

- [ ] Bug fix (non-breaking, fixes a specific issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [x] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Changes

### GitHub Release Creation/Update
- Changed from always creating a new release to checking if one already exists
- If release exists: updates the release metadata (title, notes) and uploads/clobbers assets
- If release doesn't exist: creates it as before
- Both paths emit appropriate notices to the workflow summary

### Crates.io Publication
- Wrapped `cargo publish` with error handling to detect "already uploaded" scenarios
- If the version is already published on crates.io, logs a warning and continues
- Other publish failures still cause the workflow to exit with an error
- Captures publish output to a temporary log file for inspection

## Checklist

### Code quality
- [x] No code tests needed (CI/workflow changes only)
- [x] Changes follow existing shell script patterns in the workflow
- [x] Error handling is explicit and informative

### Documentation
- [x] Workflow behavior is self-documenting via comments explaining the idempotent logic
- [x] No user-facing changes requiring CHANGELOG update

https://claude.ai/code/session_018YRh1AVsaHnJanMui7LnYg