### PR TITLE
Fix logo visibility rules to prevent theme flash and CSS conflicts

### DIFF
--- a/book/theme/custom.css
+++ b/book/theme/custom.css
@@ -13,19 +13,28 @@
   display: none;        /* hidden until theme class reveals one */
 }
 
-/* light / rust / ayu → show light logo.
-   mdBook sets the theme class on <html>, not <body>. */
-.light  .book-logo-light,
-.rust   .book-logo-light,
-.ayu    .book-logo-light { display: inline-block; }
+/* light / rust → light logo visible, dark logo explicitly hidden.
+   mdBook sets the theme class on <html>, not <body>.
+   Explicit per-theme hide rules ([0,2,1]) prevent any mdBook theme CSS
+   from accidentally overriding the base display:none ([0,1,1]). */
+.light .book-logo-light,
+.rust  .book-logo-light { display: inline-block; }
+.light .book-logo-dark,
+.rust  .book-logo-dark  { display: none; }
 
-/* coal / navy → show dark logo */
-.coal   .book-logo-dark,
-.navy   .book-logo-dark  { display: inline-block; }
+/* ayu / coal / navy → dark logo visible, light logo explicitly hidden.
+   ayu is a dark theme and should show the dark logo. */
+.ayu  .book-logo-dark,
+.coal .book-logo-dark,
+.navy .book-logo-dark  { display: inline-block; }
+.ayu  .book-logo-light,
+.coal .book-logo-light,
+.navy .book-logo-light { display: none; }
 
-/* fallback: if no theme class yet (first paint), show light logo.
-   Must target html (not body) because mdBook sets the theme class on <html>. */
-html:not(.coal):not(.navy) .book-logo-light { display: inline-block; }
+/* fallback: first paint before JS applies the theme class — show light logo.
+   Excludes ayu/coal/navy so they don't flash the light logo before the
+   theme class lands.  Specificity [0,4,1] safely beats the base rule. */
+html:not(.ayu):not(.coal):not(.navy) .book-logo-light { display: inline-block; }
 
 /* ── Typography ─────────────────────────────────────────────────────────── */
 :root {


### PR DESCRIPTION
## Summary

This PR fixes the CSS rules for logo visibility across mdBook themes to prevent the light logo from flashing on page load for dark themes (ayu, coal, navy) and to explicitly hide logos per-theme, preventing mdBook's theme CSS from accidentally overriding the base display rules. The changes reorganize the selectors to group themes by their logo type and add explicit `display: none` rules with higher specificity to ensure correct logo visibility in all scenarios.

## Type of change

- [x] Bug fix (non-breaking, fixes a specific issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [ ] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Details

**Problem:** The original CSS had two issues:
1. The fallback rule `html:not(.coal):not(.navy) .book-logo-light` would match ayu theme on first paint, causing the light logo to flash before the theme class is applied
2. Only showing logos without explicitly hiding the opposite logo type allowed mdBook's theme CSS to override the base `display: none` rule

**Solution:**
- Reorganized rules to group light themes (light, rust) and dark themes (ayu, coal, navy)
- Added explicit `display: none` rules for each theme to hide the non-applicable logo
- Updated the fallback rule to exclude all dark themes: `html:not(.ayu):not(.coal):not(.navy)`
- Increased specificity of the fallback rule to `[0,4,1]` to safely override the base rule
- Updated comments to explain the CSS specificity strategy

## Checklist

### Code quality
- [x] No automated tests affected (CSS-only change)
- [x] No unsafe code involved
- [x] Change is straightforward and localized to theme logo visibility

### Documentation
- [x] Book theme CSS is internal implementation detail; no documentation updates needed

https://claude.ai/code/session_018b3fVq9huzLdX1vyvcyLgh