### PR TITLE
Add mock testing utilities for callbacks and registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "duckdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quack-rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Tom F. <tomf@tomtomtech.net>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,31 @@ crate-type = ["rlib"]
 ## on crates.io, at which point version-specific wrappers will be added behind it.
 duckdb-1-5 = []
 
+## Links a bundled copy of DuckDB for integration testing.
+##
+## When this feature is enabled, the `testing::InMemoryDb` helper becomes available.
+## It opens a real in-memory DuckDB database using the `duckdb` Rust crate, which
+## bypasses the `loadable-extension` dispatch mechanism entirely.
+##
+## # Important: architectural limitation
+##
+## Even with this feature, quack-rs's own wrappers (`VectorReader`, `VectorWriter`,
+## `Connection::register_*`) still route through the `loadable-extension` dispatch
+## table and cannot be called in `cargo test`. Use `InMemoryDb` for SQL-level
+## assertions (e.g. verifying SQL macro output) and `MockVectorWriter` /
+## `MockVectorReader` for callback logic tests.
+##
+## # Usage in your extension
+##
+## ```toml
+## [dev-dependencies]
+## quack-rs = { version = "0.5", features = ["bundled-test"] }
+## ```
+bundled-test = ["dep:duckdb"]
+
 [dependencies]
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
+duckdb = { version = ">=1.4.4, <2", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 duckdb = { version = ">=1.4.4, <2", features = ["bundled"] }

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -155,6 +155,12 @@ DuckDB without going through the `loadable-extension` dispatch:
 quack-rs = { version = "0.5", features = ["bundled-test"] }
 ```
 
+> **Build time**: enabling `bundled-test` compiles a full copy of DuckDB from
+> source (the `duckdb` Rust crate with `features = ["bundled"]`). Expect a
+> 2–5 minute incremental build the first time, depending on your machine. This
+> only affects the test build — it has no impact on your extension's release
+> binary.
+
 ```rust,no_run
 # #[cfg(feature = "bundled-test")]
 use quack_rs::testing::InMemoryDb;

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -6,6 +6,183 @@ inside an actual DuckDB process.
 
 ---
 
+## Architectural limitation: the `loadable-extension` dispatch wall
+
+This is the most important thing to understand before writing tests.
+
+`DuckDB` loadable extensions use `libduckdb-sys` with
+`features = ["loadable-extension"]`. This intentionally **does not link the
+DuckDB runtime** into the extension binary. Instead, every DuckDB C API call
+(`duckdb_vector_get_data`, `duckdb_create_logical_type`, etc.) goes through a
+lazy dispatch table — a global struct of `AtomicPtr<fn>` pointers initialized
+only when DuckDB calls `duckdb_rs_extension_api_init` at extension-load time.
+
+**In `cargo test`, no DuckDB process loads your extension.** The dispatch table
+is never initialized, and the first call to any DuckDB C API function panics:
+
+```text
+DuckDB API not initialized
+```
+
+### What this breaks
+
+| API | Why it fails |
+|-----|--------------|
+| `VectorReader::new` | calls `duckdb_vector_get_data` |
+| `VectorWriter::new` | calls `duckdb_vector_get_data` |
+| `Connection::register_*` | calls DuckDB registration C API |
+| `LogicalType::new` | calls `duckdb_create_logical_type` |
+| `LogicalType::drop` | calls `duckdb_destroy_logical_type` |
+| `BindInfo::add_result_column` | calls `duckdb_bind_add_result_column` |
+
+### What still works in `cargo test`
+
+| API | Why it works |
+|-----|--------------|
+| `AggregateTestHarness` | pure Rust, zero DuckDB dependency |
+| `MockVectorWriter` / `MockVectorReader` | in-memory buffers, zero DuckDB dependency |
+| `MockRegistrar` | records registrations without calling C API |
+| `SqlMacro::to_sql()` | generates SQL strings, no DuckDB needed |
+| `interval_to_micros` | pure arithmetic |
+| `validate` / `scaffold` | pure Rust |
+| `InMemoryDb` | uses bundled DuckDB via `duckdb` crate (`bundled-test` feature) |
+
+---
+
+## Mock types for callback logic
+
+When your scalar or table function callback reads inputs and writes outputs,
+extract that logic into a pure-Rust function. Then test it with
+`MockVectorReader` (input) and `MockVectorWriter` (output):
+
+```rust
+use quack_rs::testing::{MockVectorReader, MockVectorWriter};
+
+// Pure Rust logic — extracted from the FFI callback
+fn compute_upper(reader: &MockVectorReader, writer: &mut MockVectorWriter) {
+    for i in 0..reader.row_count() {
+        if reader.is_valid(i) {
+            let s = reader.try_get_str(i).unwrap_or("");
+            writer.write_varchar(i, &s.to_uppercase());
+        } else {
+            writer.set_null(i);
+        }
+    }
+}
+
+#[test]
+fn test_compute_upper() {
+    let reader = MockVectorReader::from_strs([Some("hello"), None, Some("world")]);
+    let mut writer = MockVectorWriter::new(3);
+    compute_upper(&reader, &mut writer);
+
+    assert_eq!(writer.try_get_str(0), Some("HELLO"));
+    assert!(writer.is_null(1));
+    assert_eq!(writer.try_get_str(2), Some("WORLD"));
+}
+```
+
+The real FFI callback becomes a thin wrapper:
+
+```rust,no_run
+unsafe extern "C" fn my_scalar(
+    _info: duckdb_function_info,
+    input: duckdb_data_chunk,
+    output: duckdb_vector,
+) {
+    // Real DuckDB wrappers — only used in production, not in cargo test
+    let reader = unsafe { VectorReader::new(input, 0) };
+    let mut writer = unsafe { VectorWriter::new(output) };
+    // TODO: adapt mock-compatible logic to real readers/writers
+}
+```
+
+---
+
+## Testing registration with `MockRegistrar`
+
+`MockRegistrar` implements the `Registrar` trait without calling any DuckDB C API.
+Use it to verify your registration function registers the right set of functions:
+
+```rust
+use quack_rs::connection::Registrar;
+use quack_rs::testing::MockRegistrar;
+use quack_rs::scalar::ScalarFunctionBuilder;
+use quack_rs::types::TypeId;
+use quack_rs::error::ExtensionError;
+
+fn register_all(reg: &impl Registrar) -> Result<(), ExtensionError> {
+    let upper = ScalarFunctionBuilder::new("upper_ext")
+        .param(TypeId::Varchar)
+        .returns(TypeId::Varchar);
+    let lower = ScalarFunctionBuilder::new("lower_ext")
+        .param(TypeId::Varchar)
+        .returns(TypeId::Varchar);
+    unsafe {
+        reg.register_scalar(upper)?;
+        reg.register_scalar(lower)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_register_all() {
+    let mock = MockRegistrar::new();
+    register_all(&mock).unwrap();
+    assert_eq!(mock.total_registrations(), 2);
+    assert!(mock.has_scalar("upper_ext"));
+    assert!(mock.has_scalar("lower_ext"));
+}
+```
+
+> **Limitation**: `MockRegistrar` cannot be used with builders that hold
+> `LogicalType` values (created via `.returns_logical()` or `.param_logical()`),
+> because `LogicalType::drop` calls `duckdb_destroy_logical_type`. Use `TypeId`
+> parameters with `MockRegistrar`.
+
+---
+
+## SQL-level testing with `InMemoryDb` (`bundled-test` feature)
+
+For SQL-level assertions — verifying that a SQL macro produces the correct output,
+or that a CREATE TABLE + INSERT + SELECT pipeline works — enable the `bundled-test`
+Cargo feature. This provides `InMemoryDb`, which wraps the `duckdb` crate's bundled
+DuckDB without going through the `loadable-extension` dispatch:
+
+```toml
+# In your extension's Cargo.toml
+[dev-dependencies]
+quack-rs = { version = "0.5", features = ["bundled-test"] }
+```
+
+```rust,no_run
+# #[cfg(feature = "bundled-test")]
+use quack_rs::testing::InMemoryDb;
+use quack_rs::sql_macro::SqlMacro;
+
+#[test]
+fn test_clamp_macro_sql() {
+    let db = InMemoryDb::open().unwrap();
+
+    // Generate and execute the CREATE MACRO SQL
+    let m = SqlMacro::scalar("clamp", &["x", "lo", "hi"], "greatest(lo, least(hi, x))").unwrap();
+    db.execute_batch(&m.to_sql()).unwrap();
+
+    // Verify correct output
+    let result: i64 = db.query_one("SELECT clamp(5, 1, 10)").unwrap();
+    assert_eq!(result, 5);
+
+    let clamped: i64 = db.query_one("SELECT clamp(15, 1, 10)").unwrap();
+    assert_eq!(clamped, 10);
+}
+```
+
+> **Note**: `InMemoryDb` cannot test your FFI callbacks (`VectorReader`,
+> `VectorWriter`) because those still route through the `loadable-extension`
+> dispatch. Use `InMemoryDb` for SQL logic and mocks for callback logic.
+
+---
+
 ## Why two tiers?
 
 > **Pitfall P3** — Unit tests are insufficient. 435 unit tests passed in

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/aggregate/builder/set.rs
+++ b/src/aggregate/builder/set.rs
@@ -114,6 +114,13 @@ impl AggregateFunctionSetBuilder {
         })
     }
 
+    /// Returns the function set name.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub fn name(&self) -> &str {
+        self.name.to_str().unwrap_or("")
+    }
+
     /// Sets the return type for all overloads in this function set.
     ///
     /// For complex return types like `LIST(BIGINT)`, use

--- a/src/aggregate/builder/single.rs
+++ b/src/aggregate/builder/single.rs
@@ -122,6 +122,13 @@ impl AggregateFunctionBuilder {
         })
     }
 
+    /// Returns the function name.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub fn name(&self) -> &str {
+        self.name.to_str().unwrap_or("")
+    }
+
     /// Adds a positional parameter with the given type.
     ///
     /// Call this once per parameter in order. For complex types like

--- a/src/cast/builder.rs
+++ b/src/cast/builder.rs
@@ -213,6 +213,20 @@ impl CastFunctionBuilder {
         }
     }
 
+    /// Returns the source type this cast converts from.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub const fn source(&self) -> TypeId {
+        self.source
+    }
+
+    /// Returns the target type this cast converts to.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub const fn target(&self) -> TypeId {
+        self.target
+    }
+
     /// Sets the cast callback.
     pub fn function(mut self, f: CastFn) -> Self {
         self.function = Some(f);

--- a/src/scalar/builder/set.rs
+++ b/src/scalar/builder/set.rs
@@ -110,6 +110,13 @@ impl ScalarFunctionSetBuilder {
         })
     }
 
+    /// Returns the function set name.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub fn name(&self) -> &str {
+        self.name.to_str().unwrap_or("")
+    }
+
     /// Adds a single overload to this function set.
     pub fn overload(mut self, builder: ScalarOverloadBuilder) -> Self {
         self.overloads.push(ScalarOverloadSpec {

--- a/src/scalar/builder/single.rs
+++ b/src/scalar/builder/single.rs
@@ -110,6 +110,13 @@ impl ScalarFunctionBuilder {
         })
     }
 
+    /// Returns the function name.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub fn name(&self) -> &str {
+        self.name.to_str().unwrap_or("")
+    }
+
     /// Adds a positional parameter with the given type.
     ///
     /// Call this once per parameter in order. For complex types like

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -170,6 +170,13 @@ impl TableFunctionBuilder {
         })
     }
 
+    /// Returns the function name.
+    ///
+    /// Useful for introspection and for [`MockRegistrar`][crate::testing::MockRegistrar].
+    pub fn name(&self) -> &str {
+        self.name.to_str().unwrap_or("")
+    }
+
     /// Adds a positional parameter with the given type.
     pub fn param(mut self, type_id: TypeId) -> Self {
         self.params.push(type_id);

--- a/src/testing/in_memory_db.rs
+++ b/src/testing/in_memory_db.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! In-memory `DuckDB` helper for integration tests.
+//!
+//! Available only when the `bundled-test` feature is enabled. Provides
+//! [`InMemoryDb`], which opens a real in-memory `DuckDB` database using the
+//! bundled `duckdb` Rust crate — bypassing the `loadable-extension` dispatch
+//! mechanism entirely.
+//!
+//! # What `InMemoryDb` is for
+//!
+//! - Executing SQL statements and verifying results (e.g., after registering a
+//!   SQL macro via its raw SQL string).
+//! - Seeding test data and running `SELECT` queries to validate logic.
+//! - Any test that needs a live `DuckDB` connection but doesn't need to go
+//!   through quack-rs's FFI wrappers.
+//!
+//! # What `InMemoryDb` is NOT for
+//!
+//! `InMemoryDb` cannot be used to test quack-rs's FFI callback wrappers
+//! (`VectorReader`, `VectorWriter`, `BindInfo`, etc.) because those wrappers
+//! route through the `loadable-extension` dispatch table, which is uninitialized
+//! in `cargo test`. For callback logic, use [`MockVectorReader`] and
+//! [`MockVectorWriter`] instead.
+//!
+//! [`MockVectorReader`]: crate::testing::MockVectorReader
+//! [`MockVectorWriter`]: crate::testing::MockVectorWriter
+//!
+//! # Enabling this feature
+//!
+//! ```toml
+//! # In your extension's Cargo.toml:
+//! [dev-dependencies]
+//! quack-rs = { version = "0.5", features = ["bundled-test"] }
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "bundled-test")]
+//! # {
+//! use quack_rs::testing::InMemoryDb;
+//!
+//! let db = InMemoryDb::open().unwrap();
+//!
+//! // Execute a SQL macro directly (SQL-level test, no FFI needed)
+//! db.execute_batch("CREATE MACRO double(x) AS (x * 2)").unwrap();
+//!
+//! let result: i64 = db.query_one("SELECT double(21)").unwrap();
+//! assert_eq!(result, 42);
+//! # }
+//! ```
+
+/// An in-memory `DuckDB` database for integration testing.
+///
+/// Wraps [`duckdb::Connection`] opened in in-memory mode. Only available
+/// when the `bundled-test` feature is enabled.
+///
+/// See the [module documentation][self] for usage examples and limitations.
+pub struct InMemoryDb {
+    conn: duckdb::Connection,
+}
+
+impl InMemoryDb {
+    /// Opens a new in-memory `DuckDB` database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `DuckDB` fails to initialize an in-memory database
+    /// (extremely unlikely in practice).
+    pub fn open() -> Result<Self, duckdb::Error> {
+        Ok(Self {
+            conn: duckdb::Connection::open_in_memory()?,
+        })
+    }
+
+    /// Executes one or more SQL statements separated by semicolons.
+    ///
+    /// Useful for `CREATE TABLE`, `INSERT`, `CREATE MACRO`, etc.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any statement fails.
+    pub fn execute_batch(&self, sql: &str) -> Result<(), duckdb::Error> {
+        self.conn.execute_batch(sql)
+    }
+
+    /// Executes a single SQL statement and returns the number of affected rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the statement fails.
+    pub fn execute(&self, sql: &str) -> Result<usize, duckdb::Error> {
+        self.conn.execute(sql, [])
+    }
+
+    /// Executes a query that returns a single value and returns it.
+    ///
+    /// This is a convenience helper for `SELECT` expressions that produce exactly
+    /// one row and one column.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails, returns no rows, or the value
+    /// cannot be converted to `T`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "bundled-test")]
+    /// # {
+    /// use quack_rs::testing::InMemoryDb;
+    ///
+    /// let db = InMemoryDb::open().unwrap();
+    /// let answer: i64 = db.query_one("SELECT 6 * 7").unwrap();
+    /// assert_eq!(answer, 42);
+    /// # }
+    /// ```
+    pub fn query_one<T>(&self, sql: &str) -> Result<T, duckdb::Error>
+    where
+        T: duckdb::types::FromSql,
+    {
+        let mut stmt = self.conn.prepare(sql)?;
+        stmt.query_row([], |row| row.get(0))
+    }
+
+    /// Returns a reference to the underlying [`duckdb::Connection`].
+    ///
+    /// Use this for queries that don't fit the convenience methods above.
+    pub fn conn(&self) -> &duckdb::Connection {
+        &self.conn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_db_opens() {
+        let db = InMemoryDb::open().expect("should open in-memory db");
+        let _: i64 = db.query_one("SELECT 1").expect("should query 1");
+    }
+
+    #[test]
+    fn in_memory_db_execute_batch_and_query() {
+        let db = InMemoryDb::open().unwrap();
+        db.execute_batch("CREATE TABLE t(v INTEGER); INSERT INTO t VALUES (10), (20), (30)")
+            .unwrap();
+        let total: i64 = db.query_one("SELECT SUM(v) FROM t").unwrap();
+        assert_eq!(total, 60);
+    }
+
+    #[test]
+    fn in_memory_db_sql_macro() {
+        let db = InMemoryDb::open().unwrap();
+        // Test SQL macro SQL generation + execution
+        use crate::sql_macro::SqlMacro;
+        let macro_ = SqlMacro::scalar("triple", &["x"], "x * 3").unwrap();
+        db.execute_batch(&macro_.to_sql()).unwrap();
+        let result: i64 = db.query_one("SELECT triple(14)").unwrap();
+        assert_eq!(result, 42);
+    }
+}

--- a/src/testing/mock_registrar.rs
+++ b/src/testing/mock_registrar.rs
@@ -3,7 +3,7 @@
 // My way of giving something small back to the open source community
 // and encouraging more Rust development!
 
-//! [`MockRegistrar`] — a [`Registrar`][crate::connection::Registrar] implementation for testing.
+//! [`MockRegistrar`] — a [`Registrar`] implementation for testing.
 //!
 //! `MockRegistrar` records which functions were registered without calling any
 //! `DuckDB` C API. Use it to unit-test your registration logic — verifying that
@@ -18,7 +18,7 @@
 //! implementation calls `duckdb_destroy_logical_type`, which panics when the
 //! `DuckDB` dispatch table is uninitialized.
 //!
-//! Stick to [`TypeId`][crate::types::TypeId]-based parameter and return types
+//! Stick to [`TypeId`]-based parameter and return types
 //! when building functions for use with `MockRegistrar`.
 //!
 //! # Example
@@ -38,13 +38,10 @@
 //!     unsafe { reg.register_scalar(scalar) }
 //! }
 //!
-//! #[test]
-//! fn test_register_all_registers_expected_functions() {
-//!     let mock = MockRegistrar::new();
-//!     register_all(&mock).unwrap();
-//!     assert!(mock.has_scalar("word_count"));
-//!     assert_eq!(mock.total_registrations(), 1);
-//! }
+//! let mock = MockRegistrar::new();
+//! register_all(&mock).unwrap();
+//! assert!(mock.has_scalar("word_count"));
+//! assert_eq!(mock.total_registrations(), 1);
 //! ```
 
 use std::cell::RefCell;
@@ -59,7 +56,7 @@ use crate::table::TableFunctionBuilder;
 use crate::types::TypeId;
 
 /// A record of a single cast function registration.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CastRecord {
     /// The source type being cast from.
     pub source: TypeId,

--- a/src/testing/mock_registrar.rs
+++ b/src/testing/mock_registrar.rs
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! [`MockRegistrar`] — a [`Registrar`][crate::connection::Registrar] implementation for testing.
+//!
+//! `MockRegistrar` records which functions were registered without calling any
+//! `DuckDB` C API. Use it to unit-test your registration logic — verifying that
+//! the right functions are registered with the right names — without a live
+//! `DuckDB` instance.
+//!
+//! # Limitation: builders with `LogicalType` fields
+//!
+//! Builders that contain [`LogicalType`][crate::types::LogicalType] values (e.g.,
+//! created with `.returns_logical(...)` or `.param_logical(...)`) cannot be used
+//! with `MockRegistrar` in `loadable-extension` test mode. `LogicalType`'s `Drop`
+//! implementation calls `duckdb_destroy_logical_type`, which panics when the
+//! `DuckDB` dispatch table is uninitialized.
+//!
+//! Stick to [`TypeId`][crate::types::TypeId]-based parameter and return types
+//! when building functions for use with `MockRegistrar`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use quack_rs::connection::Registrar;
+//! use quack_rs::testing::MockRegistrar;
+//! use quack_rs::scalar::ScalarFunctionBuilder;
+//! use quack_rs::aggregate::AggregateFunctionBuilder;
+//! use quack_rs::types::TypeId;
+//! use quack_rs::error::ExtensionError;
+//!
+//! fn register_all(reg: &impl Registrar) -> Result<(), ExtensionError> {
+//!     let scalar = ScalarFunctionBuilder::new("word_count")
+//!         .param(TypeId::Varchar)
+//!         .returns(TypeId::BigInt);
+//!     unsafe { reg.register_scalar(scalar) }
+//! }
+//!
+//! #[test]
+//! fn test_register_all_registers_expected_functions() {
+//!     let mock = MockRegistrar::new();
+//!     register_all(&mock).unwrap();
+//!     assert!(mock.has_scalar("word_count"));
+//!     assert_eq!(mock.total_registrations(), 1);
+//! }
+//! ```
+
+use std::cell::RefCell;
+
+use crate::aggregate::{AggregateFunctionBuilder, AggregateFunctionSetBuilder};
+use crate::cast::CastFunctionBuilder;
+use crate::connection::Registrar;
+use crate::error::ExtensionError;
+use crate::scalar::{ScalarFunctionBuilder, ScalarFunctionSetBuilder};
+use crate::sql_macro::SqlMacro;
+use crate::table::TableFunctionBuilder;
+use crate::types::TypeId;
+
+/// A record of a single cast function registration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CastRecord {
+    /// The source type being cast from.
+    pub source: TypeId,
+    /// The target type being cast to.
+    pub target: TypeId,
+}
+
+/// An in-memory mock implementation of [`Registrar`] for unit testing.
+///
+/// All `register_*` methods succeed silently (returning `Ok(())`) and record
+/// the function name (or types for casts). No `DuckDB` C API is called.
+///
+/// # Thread safety
+///
+/// `MockRegistrar` uses `RefCell` for interior mutability and is **not** `Sync`.
+/// Call it from a single thread within your tests.
+#[derive(Debug, Default)]
+pub struct MockRegistrar {
+    scalar_names: RefCell<Vec<String>>,
+    scalar_set_names: RefCell<Vec<String>>,
+    aggregate_names: RefCell<Vec<String>>,
+    aggregate_set_names: RefCell<Vec<String>>,
+    table_names: RefCell<Vec<String>>,
+    sql_macro_names: RefCell<Vec<String>>,
+    casts: RefCell<Vec<CastRecord>>,
+}
+
+impl MockRegistrar {
+    /// Creates a new, empty `MockRegistrar`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // ── Inspection ──────────────────────────────────────────────────────────
+
+    /// Returns the names of all scalar functions registered so far.
+    #[must_use]
+    pub fn scalar_names(&self) -> Vec<String> {
+        self.scalar_names.borrow().clone()
+    }
+
+    /// Returns the names of all scalar function sets registered so far.
+    #[must_use]
+    pub fn scalar_set_names(&self) -> Vec<String> {
+        self.scalar_set_names.borrow().clone()
+    }
+
+    /// Returns the names of all aggregate functions registered so far.
+    #[must_use]
+    pub fn aggregate_names(&self) -> Vec<String> {
+        self.aggregate_names.borrow().clone()
+    }
+
+    /// Returns the names of all aggregate function sets registered so far.
+    #[must_use]
+    pub fn aggregate_set_names(&self) -> Vec<String> {
+        self.aggregate_set_names.borrow().clone()
+    }
+
+    /// Returns the names of all table functions registered so far.
+    #[must_use]
+    pub fn table_names(&self) -> Vec<String> {
+        self.table_names.borrow().clone()
+    }
+
+    /// Returns the names of all SQL macros registered so far.
+    #[must_use]
+    pub fn sql_macro_names(&self) -> Vec<String> {
+        self.sql_macro_names.borrow().clone()
+    }
+
+    /// Returns all cast registrations recorded so far.
+    #[must_use]
+    pub fn casts(&self) -> Vec<CastRecord> {
+        self.casts.borrow().clone()
+    }
+
+    /// Returns the total number of registrations across all types.
+    #[must_use]
+    pub fn total_registrations(&self) -> usize {
+        self.scalar_names.borrow().len()
+            + self.scalar_set_names.borrow().len()
+            + self.aggregate_names.borrow().len()
+            + self.aggregate_set_names.borrow().len()
+            + self.table_names.borrow().len()
+            + self.sql_macro_names.borrow().len()
+            + self.casts.borrow().len()
+    }
+
+    // ── Convenience predicates ──────────────────────────────────────────────
+
+    /// Returns `true` if a scalar function with the given name was registered.
+    #[must_use]
+    pub fn has_scalar(&self, name: &str) -> bool {
+        self.scalar_names.borrow().iter().any(|n| n == name)
+    }
+
+    /// Returns `true` if a scalar function set with the given name was registered.
+    #[must_use]
+    pub fn has_scalar_set(&self, name: &str) -> bool {
+        self.scalar_set_names.borrow().iter().any(|n| n == name)
+    }
+
+    /// Returns `true` if an aggregate function with the given name was registered.
+    #[must_use]
+    pub fn has_aggregate(&self, name: &str) -> bool {
+        self.aggregate_names.borrow().iter().any(|n| n == name)
+    }
+
+    /// Returns `true` if an aggregate function set with the given name was registered.
+    #[must_use]
+    pub fn has_aggregate_set(&self, name: &str) -> bool {
+        self.aggregate_set_names.borrow().iter().any(|n| n == name)
+    }
+
+    /// Returns `true` if a table function with the given name was registered.
+    #[must_use]
+    pub fn has_table(&self, name: &str) -> bool {
+        self.table_names.borrow().iter().any(|n| n == name)
+    }
+
+    /// Returns `true` if a SQL macro with the given name was registered.
+    #[must_use]
+    pub fn has_sql_macro(&self, name: &str) -> bool {
+        self.sql_macro_names.borrow().iter().any(|n| n == name)
+    }
+}
+
+impl Registrar for MockRegistrar {
+    /// Records a scalar function registration. Never calls `DuckDB` C API.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context — no `DuckDB`
+    /// connection is required.
+    unsafe fn register_scalar(&self, builder: ScalarFunctionBuilder) -> Result<(), ExtensionError> {
+        self.scalar_names
+            .borrow_mut()
+            .push(builder.name().to_owned());
+        Ok(())
+    }
+
+    /// Records a scalar function set registration. Never calls `DuckDB` C API.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context.
+    unsafe fn register_scalar_set(
+        &self,
+        builder: ScalarFunctionSetBuilder,
+    ) -> Result<(), ExtensionError> {
+        self.scalar_set_names
+            .borrow_mut()
+            .push(builder.name().to_owned());
+        Ok(())
+    }
+
+    /// Records an aggregate function registration. Never calls `DuckDB` C API.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context.
+    unsafe fn register_aggregate(
+        &self,
+        builder: AggregateFunctionBuilder,
+    ) -> Result<(), ExtensionError> {
+        self.aggregate_names
+            .borrow_mut()
+            .push(builder.name().to_owned());
+        Ok(())
+    }
+
+    /// Records an aggregate function set registration. Never calls `DuckDB` C API.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context.
+    unsafe fn register_aggregate_set(
+        &self,
+        builder: AggregateFunctionSetBuilder,
+    ) -> Result<(), ExtensionError> {
+        self.aggregate_set_names
+            .borrow_mut()
+            .push(builder.name().to_owned());
+        Ok(())
+    }
+
+    /// Records a table function registration. Never calls `DuckDB` C API.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context.
+    unsafe fn register_table(&self, builder: TableFunctionBuilder) -> Result<(), ExtensionError> {
+        self.table_names
+            .borrow_mut()
+            .push(builder.name().to_owned());
+        Ok(())
+    }
+
+    /// Records a SQL macro registration. Never calls `DuckDB` C API.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context.
+    unsafe fn register_sql_macro(&self, sql_macro: SqlMacro) -> Result<(), ExtensionError> {
+        self.sql_macro_names
+            .borrow_mut()
+            .push(sql_macro.name().to_owned());
+        Ok(())
+    }
+
+    /// Records a cast function registration. Never calls `DuckDB` C API.
+    ///
+    /// The source and target types are captured from the builder.
+    ///
+    /// # Safety
+    ///
+    /// This implementation is safe to call in any context.
+    unsafe fn register_cast(&self, builder: CastFunctionBuilder) -> Result<(), ExtensionError> {
+        self.casts.borrow_mut().push(CastRecord {
+            source: builder.source(),
+            target: builder.target(),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::TypeId;
+
+    #[test]
+    fn mock_registrar_records_scalar() {
+        let mock = MockRegistrar::new();
+        let builder = ScalarFunctionBuilder::new("my_fn")
+            .param(TypeId::BigInt)
+            .returns(TypeId::BigInt);
+        unsafe { mock.register_scalar(builder).unwrap() };
+        assert!(mock.has_scalar("my_fn"));
+        assert_eq!(mock.scalar_names(), vec!["my_fn"]);
+        assert_eq!(mock.total_registrations(), 1);
+    }
+
+    #[test]
+    fn mock_registrar_records_aggregate() {
+        let mock = MockRegistrar::new();
+        let builder = AggregateFunctionBuilder::new("my_agg")
+            .param(TypeId::BigInt)
+            .returns(TypeId::BigInt);
+        unsafe { mock.register_aggregate(builder).unwrap() };
+        assert!(mock.has_aggregate("my_agg"));
+        assert_eq!(mock.total_registrations(), 1);
+    }
+
+    #[test]
+    fn mock_registrar_records_table() {
+        let mock = MockRegistrar::new();
+        let builder = TableFunctionBuilder::new("my_table");
+        unsafe { mock.register_table(builder).unwrap() };
+        assert!(mock.has_table("my_table"));
+        assert_eq!(mock.total_registrations(), 1);
+    }
+
+    #[test]
+    fn mock_registrar_records_sql_macro() {
+        let mock = MockRegistrar::new();
+        let macro_ = SqlMacro::scalar("my_macro", &["x"], "x + 1").unwrap();
+        unsafe { mock.register_sql_macro(macro_).unwrap() };
+        assert!(mock.has_sql_macro("my_macro"));
+        assert_eq!(mock.total_registrations(), 1);
+    }
+
+    #[test]
+    fn mock_registrar_records_cast() {
+        let mock = MockRegistrar::new();
+        let builder = CastFunctionBuilder::new(TypeId::Varchar, TypeId::Integer);
+        unsafe { mock.register_cast(builder).unwrap() };
+        let casts = mock.casts();
+        assert_eq!(casts.len(), 1);
+        assert_eq!(casts[0].source, TypeId::Varchar);
+        assert_eq!(casts[0].target, TypeId::Integer);
+        assert_eq!(mock.total_registrations(), 1);
+    }
+
+    #[test]
+    fn mock_registrar_multiple_registrations() {
+        let mock = MockRegistrar::new();
+
+        let s1 = ScalarFunctionBuilder::new("fn_one")
+            .param(TypeId::BigInt)
+            .returns(TypeId::BigInt);
+        let s2 = ScalarFunctionBuilder::new("fn_two")
+            .param(TypeId::Varchar)
+            .returns(TypeId::Integer);
+
+        unsafe {
+            mock.register_scalar(s1).unwrap();
+            mock.register_scalar(s2).unwrap();
+        }
+
+        assert_eq!(mock.total_registrations(), 2);
+        assert!(mock.has_scalar("fn_one"));
+        assert!(mock.has_scalar("fn_two"));
+        assert!(!mock.has_scalar("fn_three"));
+    }
+
+    #[test]
+    fn mock_registrar_used_with_generic_registrar() {
+        // Demonstrates using MockRegistrar where &impl Registrar is expected.
+        fn register_all(reg: &impl Registrar) -> Result<(), ExtensionError> {
+            let s = ScalarFunctionBuilder::new("compute")
+                .param(TypeId::Integer)
+                .returns(TypeId::Integer);
+            unsafe { reg.register_scalar(s) }
+        }
+
+        let mock = MockRegistrar::new();
+        register_all(&mock).unwrap();
+        assert!(mock.has_scalar("compute"));
+    }
+}

--- a/src/testing/mock_vector.rs
+++ b/src/testing/mock_vector.rs
@@ -17,7 +17,7 @@
 //! `duckdb_rs_extension_api_init` at extension load time. In `cargo test`, no
 //! `DuckDB` process loads the extension, so the dispatch table is never
 //! initialized and any call to `VectorReader::new` or `VectorWriter::new` panics
-//! with "DuckDB API not initialized".
+//! with `DuckDB API not initialized`.
 //!
 //! These mock types provide the same write/read interface but store data in a
 //! plain `Vec`, with no `DuckDB` dependency at all.
@@ -42,17 +42,14 @@
 //!     }
 //! }
 //!
-//! #[test]
-//! fn test_double_logic() {
-//!     let reader = MockVectorReader::from_i64s([Some(1), Some(5), None, Some(-3)]);
-//!     let mut writer = MockVectorWriter::new(4);
-//!     compute_double(&reader, &mut writer);
+//! let reader = MockVectorReader::from_i64s([Some(1), Some(5), None, Some(-3)]);
+//! let mut writer = MockVectorWriter::new(4);
+//! compute_double(&reader, &mut writer);
 //!
-//!     assert_eq!(writer.try_get_i64(0), Some(2));
-//!     assert_eq!(writer.try_get_i64(1), Some(10));
-//!     assert!(writer.is_null(2));
-//!     assert_eq!(writer.try_get_i64(3), Some(-6));
-//! }
+//! assert_eq!(writer.try_get_i64(0), Some(2));
+//! assert_eq!(writer.try_get_i64(1), Some(10));
+//! assert!(writer.is_null(2));
+//! assert_eq!(writer.try_get_i64(3), Some(-6));
 //! ```
 
 use crate::interval::DuckInterval;
@@ -144,7 +141,7 @@ impl MockVectorWriter {
     /// Returns `true` if row `idx` is NULL or has not been written.
     #[must_use]
     pub fn is_null(&self, idx: usize) -> bool {
-        self.rows.get(idx).map_or(true, |v| v.is_none())
+        self.rows.get(idx).is_none_or(Option::is_none)
     }
 
     /// Returns the number of allocated rows (including NULLs).
@@ -400,7 +397,7 @@ impl MockVectorReader {
     /// Always returns `false` for out-of-bounds indices.
     #[must_use]
     pub fn is_valid(&self, idx: usize) -> bool {
-        self.rows.get(idx).map_or(false, |v| v.is_some())
+        self.rows.get(idx).is_some_and(Option::is_some)
     }
 
     /// Returns the raw value at row `idx`, or `None` if NULL or out of bounds.
@@ -518,7 +515,7 @@ mod tests {
         w.write_u8(4, 255);
         w.write_u32(5, 999);
         w.write_u64(6, u64::MAX);
-        w.write_f32(7, 3.14_f32);
+        w.write_f32(7, std::f32::consts::PI);
         w.write_f64(8, std::f64::consts::PI);
         w.write_bool(9, true);
 

--- a/src/testing/mock_vector.rs
+++ b/src/testing/mock_vector.rs
@@ -1,0 +1,583 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! In-memory mock types for `DuckDB` vectors.
+//!
+//! [`MockVectorWriter`] and [`MockVectorReader`] let you test callback logic —
+//! the code that reads input rows and writes output values — without a live
+//! `DuckDB` instance.
+//!
+//! # Why these exist
+//!
+//! `DuckDB` loadable extensions use `libduckdb-sys` with
+//! `features = ["loadable-extension"]`, which routes every C API call through a
+//! lazy dispatch table. That table is only initialized when `DuckDB` calls
+//! `duckdb_rs_extension_api_init` at extension load time. In `cargo test`, no
+//! `DuckDB` process loads the extension, so the dispatch table is never
+//! initialized and any call to `VectorReader::new` or `VectorWriter::new` panics
+//! with "DuckDB API not initialized".
+//!
+//! These mock types provide the same write/read interface but store data in a
+//! plain `Vec`, with no `DuckDB` dependency at all.
+//!
+//! # Recommended pattern
+//!
+//! Extract your callback logic into a pure-Rust function, then call it from both
+//! the FFI callback (with the real writer) and your tests (with the mock):
+//!
+//! ```rust
+//! use quack_rs::testing::{MockVectorWriter, MockVectorReader, MockDuckValue};
+//!
+//! /// Pure business logic — testable without DuckDB.
+//! fn compute_double(reader: &MockVectorReader, writer: &mut MockVectorWriter) {
+//!     for i in 0..reader.row_count() {
+//!         if reader.is_valid(i) {
+//!             let v = reader.try_get_i64(i).unwrap_or(0);
+//!             writer.write_i64(i, v * 2);
+//!         } else {
+//!             writer.set_null(i);
+//!         }
+//!     }
+//! }
+//!
+//! #[test]
+//! fn test_double_logic() {
+//!     let reader = MockVectorReader::from_i64s([Some(1), Some(5), None, Some(-3)]);
+//!     let mut writer = MockVectorWriter::new(4);
+//!     compute_double(&reader, &mut writer);
+//!
+//!     assert_eq!(writer.try_get_i64(0), Some(2));
+//!     assert_eq!(writer.try_get_i64(1), Some(10));
+//!     assert!(writer.is_null(2));
+//!     assert_eq!(writer.try_get_i64(3), Some(-6));
+//! }
+//! ```
+
+use crate::interval::DuckInterval;
+
+/// A `DuckDB`-compatible value variant for testing.
+///
+/// Used by both [`MockVectorWriter`] and [`MockVectorReader`] to represent the
+/// typed values in a column without requiring a live `DuckDB` runtime.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum MockDuckValue {
+    /// `TINYINT` / `INT8`
+    I8(i8),
+    /// `SMALLINT` / `INT16`
+    I16(i16),
+    /// `INTEGER` / `INT32`
+    I32(i32),
+    /// `BIGINT` / `INT64`
+    I64(i64),
+    /// `UTINYINT` / `UINT8`
+    U8(u8),
+    /// `USMALLINT` / `UINT16`
+    U16(u16),
+    /// `UINTEGER` / `UINT32`
+    U32(u32),
+    /// `UBIGINT` / `UINT64`
+    U64(u64),
+    /// `FLOAT`
+    F32(f32),
+    /// `DOUBLE`
+    F64(f64),
+    /// `BOOLEAN`
+    Bool(bool),
+    /// `HUGEINT`
+    I128(i128),
+    /// `VARCHAR`
+    Varchar(String),
+    /// `INTERVAL`
+    Interval(DuckInterval),
+}
+
+/// An in-memory mock output vector for testing finalize and scan callbacks.
+///
+/// Write typed values and NULL flags using the same method names as
+/// [`VectorWriter`][crate::vector::VectorWriter]. Inspect the results with
+/// [`try_get_i64`][Self::try_get_i64], [`is_null`][Self::is_null], etc.
+///
+/// # Example
+///
+/// ```rust
+/// use quack_rs::testing::{MockVectorWriter, MockDuckValue};
+///
+/// let mut w = MockVectorWriter::new(3);
+/// w.write_i64(0, 42);
+/// w.write_i64(1, -7);
+/// w.set_null(2);
+///
+/// assert_eq!(w.try_get_i64(0), Some(42));
+/// assert_eq!(w.try_get_i64(1), Some(-7));
+/// assert!(w.is_null(2));
+/// ```
+#[derive(Debug, Default)]
+pub struct MockVectorWriter {
+    rows: Vec<Option<MockDuckValue>>,
+}
+
+impl MockVectorWriter {
+    /// Creates a new writer pre-allocated for `capacity` rows (all NULL).
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            rows: vec![None; capacity],
+        }
+    }
+
+    /// Ensures the internal buffer is large enough to hold row `idx`.
+    fn ensure_capacity(&mut self, idx: usize) {
+        if idx >= self.rows.len() {
+            self.rows.resize(idx + 1, None);
+        }
+    }
+
+    /// Marks row `idx` as NULL.
+    pub fn set_null(&mut self, idx: usize) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = None;
+    }
+
+    /// Returns `true` if row `idx` is NULL or has not been written.
+    #[must_use]
+    pub fn is_null(&self, idx: usize) -> bool {
+        self.rows.get(idx).map_or(true, |v| v.is_none())
+    }
+
+    /// Returns the number of allocated rows (including NULLs).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Returns `true` if no rows have been allocated.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Returns the raw `Option<MockDuckValue>` for row `idx`.
+    ///
+    /// Returns `None` if the row is NULL or has never been written.
+    #[must_use]
+    pub fn get(&self, idx: usize) -> Option<&MockDuckValue> {
+        self.rows.get(idx).and_then(|v| v.as_ref())
+    }
+
+    // ── Numeric writes ──────────────────────────────────────────────────────
+
+    /// Writes a `TINYINT` value at row `idx`.
+    pub fn write_i8(&mut self, idx: usize, value: i8) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::I8(value));
+    }
+
+    /// Writes a `SMALLINT` value at row `idx`.
+    pub fn write_i16(&mut self, idx: usize, value: i16) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::I16(value));
+    }
+
+    /// Writes an `INTEGER` value at row `idx`.
+    pub fn write_i32(&mut self, idx: usize, value: i32) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::I32(value));
+    }
+
+    /// Writes a `BIGINT` value at row `idx`.
+    pub fn write_i64(&mut self, idx: usize, value: i64) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::I64(value));
+    }
+
+    /// Writes a `UTINYINT` value at row `idx`.
+    pub fn write_u8(&mut self, idx: usize, value: u8) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::U8(value));
+    }
+
+    /// Writes a `USMALLINT` value at row `idx`.
+    pub fn write_u16(&mut self, idx: usize, value: u16) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::U16(value));
+    }
+
+    /// Writes a `UINTEGER` value at row `idx`.
+    pub fn write_u32(&mut self, idx: usize, value: u32) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::U32(value));
+    }
+
+    /// Writes a `UBIGINT` value at row `idx`.
+    pub fn write_u64(&mut self, idx: usize, value: u64) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::U64(value));
+    }
+
+    /// Writes a `FLOAT` value at row `idx`.
+    pub fn write_f32(&mut self, idx: usize, value: f32) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::F32(value));
+    }
+
+    /// Writes a `DOUBLE` value at row `idx`.
+    pub fn write_f64(&mut self, idx: usize, value: f64) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::F64(value));
+    }
+
+    /// Writes a `BOOLEAN` value at row `idx`.
+    pub fn write_bool(&mut self, idx: usize, value: bool) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::Bool(value));
+    }
+
+    /// Writes a `HUGEINT` value at row `idx`.
+    pub fn write_i128(&mut self, idx: usize, value: i128) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::I128(value));
+    }
+
+    /// Writes a `VARCHAR` value at row `idx`.
+    pub fn write_varchar(&mut self, idx: usize, value: &str) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::Varchar(value.to_owned()));
+    }
+
+    /// Writes an `INTERVAL` value at row `idx`.
+    pub fn write_interval(&mut self, idx: usize, value: DuckInterval) {
+        self.ensure_capacity(idx);
+        self.rows[idx] = Some(MockDuckValue::Interval(value));
+    }
+
+    // ── Typed getters ───────────────────────────────────────────────────────
+
+    /// Returns the `BIGINT` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_i64(&self, idx: usize) -> Option<i64> {
+        match self.get(idx) {
+            Some(MockDuckValue::I64(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `INTEGER` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_i32(&self, idx: usize) -> Option<i32> {
+        match self.get(idx) {
+            Some(MockDuckValue::I32(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `DOUBLE` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_f64(&self, idx: usize) -> Option<f64> {
+        match self.get(idx) {
+            Some(MockDuckValue::F64(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `BOOLEAN` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_bool(&self, idx: usize) -> Option<bool> {
+        match self.get(idx) {
+            Some(MockDuckValue::Bool(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `VARCHAR` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_str(&self, idx: usize) -> Option<&str> {
+        match self.get(idx) {
+            Some(MockDuckValue::Varchar(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns the `INTERVAL` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_interval(&self, idx: usize) -> Option<DuckInterval> {
+        match self.get(idx) {
+            Some(MockDuckValue::Interval(v)) => Some(*v),
+            _ => None,
+        }
+    }
+}
+
+/// An in-memory mock input vector for testing update and scan callbacks.
+///
+/// Construct from typed slices using the convenience constructors, then call
+/// `row_count()`, `is_valid()`, and `try_get_*()` in your callback logic,
+/// matching the method names used in real `DuckDB` callbacks.
+///
+/// # Example
+///
+/// ```rust
+/// use quack_rs::testing::{MockVectorReader, MockDuckValue};
+///
+/// let reader = MockVectorReader::from_i64s([Some(10), None, Some(30)]);
+/// assert_eq!(reader.row_count(), 3);
+/// assert!(reader.is_valid(0));
+/// assert!(!reader.is_valid(1));
+/// assert_eq!(reader.try_get_i64(0), Some(10));
+/// assert_eq!(reader.try_get_i64(1), None); // NULL row
+/// assert_eq!(reader.try_get_i64(2), Some(30));
+/// ```
+#[derive(Debug, Clone)]
+pub struct MockVectorReader {
+    rows: Vec<Option<MockDuckValue>>,
+}
+
+impl MockVectorReader {
+    /// Creates a reader from an arbitrary sequence of `Option<MockDuckValue>`.
+    ///
+    /// `None` entries represent NULL rows.
+    #[must_use]
+    pub fn new(rows: impl IntoIterator<Item = Option<MockDuckValue>>) -> Self {
+        Self {
+            rows: rows.into_iter().collect(),
+        }
+    }
+
+    /// Creates a reader from a sequence of `Option<i64>` values.
+    ///
+    /// Convenience constructor for `BIGINT` columns.
+    #[must_use]
+    pub fn from_i64s(values: impl IntoIterator<Item = Option<i64>>) -> Self {
+        Self::new(values.into_iter().map(|v| v.map(MockDuckValue::I64)))
+    }
+
+    /// Creates a reader from a sequence of `Option<i32>` values.
+    ///
+    /// Convenience constructor for `INTEGER` columns.
+    #[must_use]
+    pub fn from_i32s(values: impl IntoIterator<Item = Option<i32>>) -> Self {
+        Self::new(values.into_iter().map(|v| v.map(MockDuckValue::I32)))
+    }
+
+    /// Creates a reader from a sequence of `Option<f64>` values.
+    ///
+    /// Convenience constructor for `DOUBLE` columns.
+    #[must_use]
+    pub fn from_f64s(values: impl IntoIterator<Item = Option<f64>>) -> Self {
+        Self::new(values.into_iter().map(|v| v.map(MockDuckValue::F64)))
+    }
+
+    /// Creates a reader from a sequence of `Option<bool>` values.
+    ///
+    /// Convenience constructor for `BOOLEAN` columns.
+    #[must_use]
+    pub fn from_bools(values: impl IntoIterator<Item = Option<bool>>) -> Self {
+        Self::new(values.into_iter().map(|v| v.map(MockDuckValue::Bool)))
+    }
+
+    /// Creates a reader from a sequence of `Option<&str>` values.
+    ///
+    /// Convenience constructor for `VARCHAR` columns.
+    #[must_use]
+    pub fn from_strs<'a>(values: impl IntoIterator<Item = Option<&'a str>>) -> Self {
+        Self::new(
+            values
+                .into_iter()
+                .map(|v| v.map(|s| MockDuckValue::Varchar(s.to_owned()))),
+        )
+    }
+
+    /// Returns the number of rows in this reader.
+    #[must_use]
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Returns `true` if row `idx` is not NULL.
+    ///
+    /// Always returns `false` for out-of-bounds indices.
+    #[must_use]
+    pub fn is_valid(&self, idx: usize) -> bool {
+        self.rows.get(idx).map_or(false, |v| v.is_some())
+    }
+
+    /// Returns the raw value at row `idx`, or `None` if NULL or out of bounds.
+    #[must_use]
+    pub fn get(&self, idx: usize) -> Option<&MockDuckValue> {
+        self.rows.get(idx).and_then(|v| v.as_ref())
+    }
+
+    // ── Typed getters ───────────────────────────────────────────────────────
+
+    /// Returns the `BIGINT` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_i64(&self, idx: usize) -> Option<i64> {
+        match self.get(idx) {
+            Some(MockDuckValue::I64(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `INTEGER` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_i32(&self, idx: usize) -> Option<i32> {
+        match self.get(idx) {
+            Some(MockDuckValue::I32(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `DOUBLE` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_f64(&self, idx: usize) -> Option<f64> {
+        match self.get(idx) {
+            Some(MockDuckValue::F64(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `BOOLEAN` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_bool(&self, idx: usize) -> Option<bool> {
+        match self.get(idx) {
+            Some(MockDuckValue::Bool(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `VARCHAR` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_str(&self, idx: usize) -> Option<&str> {
+        match self.get(idx) {
+            Some(MockDuckValue::Varchar(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns the `INTERVAL` value at row `idx`, or `None` if NULL or wrong type.
+    #[must_use]
+    pub fn try_get_interval(&self, idx: usize) -> Option<DuckInterval> {
+        match self.get(idx) {
+            Some(MockDuckValue::Interval(v)) => Some(*v),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writer_write_and_read_i64() {
+        let mut w = MockVectorWriter::new(3);
+        w.write_i64(0, 42);
+        w.write_i64(1, -100);
+        w.set_null(2);
+        assert_eq!(w.try_get_i64(0), Some(42));
+        assert_eq!(w.try_get_i64(1), Some(-100));
+        assert!(w.is_null(2));
+    }
+
+    #[test]
+    fn writer_grows_beyond_initial_capacity() {
+        let mut w = MockVectorWriter::new(1);
+        w.write_i64(5, 99); // grows from 1 to 6
+        assert_eq!(w.len(), 6);
+        assert_eq!(w.try_get_i64(5), Some(99));
+        assert!(w.is_null(0)); // never written
+    }
+
+    #[test]
+    fn writer_set_null_clears_previous_value() {
+        let mut w = MockVectorWriter::new(1);
+        w.write_i64(0, 42);
+        assert!(!w.is_null(0));
+        w.set_null(0);
+        assert!(w.is_null(0));
+    }
+
+    #[test]
+    fn writer_varchar() {
+        let mut w = MockVectorWriter::new(2);
+        w.write_varchar(0, "hello");
+        w.set_null(1);
+        assert_eq!(w.try_get_str(0), Some("hello"));
+        assert!(w.is_null(1));
+    }
+
+    #[test]
+    fn writer_all_types_round_trip() {
+        let mut w = MockVectorWriter::new(10);
+        w.write_i8(0, 127);
+        w.write_i16(1, 1000);
+        w.write_i32(2, 100_000);
+        w.write_i64(3, 1_000_000_000);
+        w.write_u8(4, 255);
+        w.write_u32(5, 999);
+        w.write_u64(6, u64::MAX);
+        w.write_f32(7, 3.14_f32);
+        w.write_f64(8, std::f64::consts::PI);
+        w.write_bool(9, true);
+
+        assert!(matches!(w.get(0), Some(MockDuckValue::I8(127))));
+        assert!(matches!(w.get(1), Some(MockDuckValue::I16(1000))));
+        assert!(matches!(w.get(2), Some(MockDuckValue::I32(100_000))));
+        assert_eq!(w.try_get_i64(3), Some(1_000_000_000));
+        assert!(matches!(w.get(4), Some(MockDuckValue::U8(255))));
+        assert_eq!(w.try_get_bool(9), Some(true));
+    }
+
+    #[test]
+    fn reader_from_i64s() {
+        let r = MockVectorReader::from_i64s([Some(1), None, Some(3)]);
+        assert_eq!(r.row_count(), 3);
+        assert!(r.is_valid(0));
+        assert!(!r.is_valid(1));
+        assert!(r.is_valid(2));
+        assert_eq!(r.try_get_i64(0), Some(1));
+        assert_eq!(r.try_get_i64(1), None);
+        assert_eq!(r.try_get_i64(2), Some(3));
+    }
+
+    #[test]
+    fn reader_from_strs() {
+        let r = MockVectorReader::from_strs([Some("hello"), None, Some("world")]);
+        assert_eq!(r.try_get_str(0), Some("hello"));
+        assert_eq!(r.try_get_str(1), None);
+        assert_eq!(r.try_get_str(2), Some("world"));
+    }
+
+    #[test]
+    fn reader_out_of_bounds_is_invalid() {
+        let r = MockVectorReader::from_i64s([Some(1)]);
+        assert!(!r.is_valid(99));
+        assert_eq!(r.try_get_i64(99), None);
+    }
+
+    #[test]
+    fn mock_double_pattern() {
+        // Demonstrates extracting callback logic into a testable pure-Rust function.
+        fn double_values(reader: &MockVectorReader, writer: &mut MockVectorWriter) {
+            for i in 0..reader.row_count() {
+                if reader.is_valid(i) {
+                    let v = reader.try_get_i64(i).unwrap_or(0);
+                    writer.write_i64(i, v * 2);
+                } else {
+                    writer.set_null(i);
+                }
+            }
+        }
+
+        let reader = MockVectorReader::from_i64s([Some(1), Some(5), None, Some(-3)]);
+        let mut writer = MockVectorWriter::new(4);
+        double_values(&reader, &mut writer);
+
+        assert_eq!(writer.try_get_i64(0), Some(2));
+        assert_eq!(writer.try_get_i64(1), Some(10));
+        assert!(writer.is_null(2));
+        assert_eq!(writer.try_get_i64(3), Some(-6));
+    }
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -14,7 +14,7 @@
 //! | [`MockVectorWriter`] | Write values to an in-memory buffer (replaces real output vector) |
 //! | [`MockVectorReader`] | Read values from an in-memory buffer (replaces real input vector) |
 //! | [`MockRegistrar`] | Verify which functions are registered, without a `DuckDB` connection |
-//! | [`InMemoryDb`] | Open a real bundled `DuckDB` for SQL-level tests (`bundled-test` feature) |
+//! | `InMemoryDb` | Open a real bundled `DuckDB` for SQL-level tests (`bundled-test` feature) |
 //!
 //! # Architectural limitation: `loadable-extension` dispatch
 //!
@@ -44,13 +44,13 @@
 //!
 //! - **Aggregate state logic** — use [`AggregateTestHarness`]
 //! - **Callback output logic** — extract into pure Rust, test with [`MockVectorWriter`] / [`MockVectorReader`]
-//! - **Registration structure** — use [`MockRegistrar`] (builders with only [`TypeId`][crate::types::TypeId] params)
+//! - **Registration structure** — use [`MockRegistrar`] (builders with only [`TypeId`][crate::types::TypeId] parameters)
 //! - **SQL macro SQL generation** — [`SqlMacro::to_sql()`][crate::sql_macro::SqlMacro::to_sql] is pure Rust
 //! - **Interval conversions** — [`interval_to_micros`][crate::interval::interval_to_micros] is pure Rust
 //! - **Validation / scaffold** — [`validate`][crate::validate] and [`scaffold`][crate::scaffold] are pure Rust
-//! - **SQL-level results** — use [`InMemoryDb`] (requires `bundled-test` Cargo feature)
+//! - **SQL-level results** — use `InMemoryDb` (requires `bundled-test` Cargo feature)
 //!
-//! # What requires E2E tests (SQLLogicTest)
+//! # What requires E2E tests (`SQLLogicTest`)
 //!
 //! - FFI wiring correctness (entry point, callback signatures)
 //! - Function registration success (Pitfall P6: registration can fail silently)
@@ -66,7 +66,7 @@
 //! `MyState::combine` methods produce correct results. They run fast and
 //! catch logical bugs.
 //!
-//! **E2E tests (`DuckDB` CLI / `SQLLogicTest`)** verify that the FFI wiring is
+//! **E2E tests (`DuckDB` CLI / ``SQLLogicTest``)** verify that the FFI wiring is
 //! correct — that `state_size`, `state_init`, `state_destroy`, and the
 //! callback signatures match what `DuckDB` expects.
 //!

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -3,15 +3,66 @@
 // My way of giving something small back to the open source community
 // and encouraging more Rust development!
 
-//! Test utilities for aggregate function logic.
+//! Test utilities for `DuckDB` extension development.
 //!
-//! This module provides an [`AggregateTestHarness`] that lets you test your
-//! aggregate state logic — the `update` and `combine` operations — in pure Rust
-//! without spinning up a `DuckDB` instance.
+//! This module provides several complementary tools for testing extension code
+//! without spinning up a live `DuckDB` process:
+//!
+//! | Type | Purpose |
+//! |------|---------|
+//! | [`AggregateTestHarness`] | Test aggregate state update/combine/finalize logic |
+//! | [`MockVectorWriter`] | Write values to an in-memory buffer (replaces real output vector) |
+//! | [`MockVectorReader`] | Read values from an in-memory buffer (replaces real input vector) |
+//! | [`MockRegistrar`] | Verify which functions are registered, without a `DuckDB` connection |
+//! | [`InMemoryDb`] | Open a real bundled `DuckDB` for SQL-level tests (`bundled-test` feature) |
+//!
+//! # Architectural limitation: `loadable-extension` dispatch
+//!
+//! `DuckDB` loadable extensions use `libduckdb-sys` with
+//! `features = ["loadable-extension"]`. This routes every `DuckDB` C API call
+//! through a lazy dispatch table (a global `AtomicPtr` per function). The table
+//! is only initialized when `DuckDB` calls `duckdb_rs_extension_api_init` at
+//! extension-load time.
+//!
+//! **In `cargo test`, no `DuckDB` process loads the extension**, so the dispatch
+//! table is never initialized. Any code that calls a `DuckDB` C API function will
+//! panic with:
+//!
+//! ```text
+//! DuckDB API not initialized
+//! ```
+//!
+//! This affects:
+//!
+//! - `VectorReader::new` and `VectorWriter::new` — both call `duckdb_vector_get_data`
+//! - `Connection::register_*` — calls registration C API functions
+//! - `LogicalType::new` — calls `duckdb_create_logical_type`; `LogicalType::drop` calls
+//!   `duckdb_destroy_logical_type`
+//! - Any other code that touches `libduckdb-sys` symbols
+//!
+//! # What CAN be tested with `cargo test`
+//!
+//! - **Aggregate state logic** — use [`AggregateTestHarness`]
+//! - **Callback output logic** — extract into pure Rust, test with [`MockVectorWriter`] / [`MockVectorReader`]
+//! - **Registration structure** — use [`MockRegistrar`] (builders with only [`TypeId`][crate::types::TypeId] params)
+//! - **SQL macro SQL generation** — [`SqlMacro::to_sql()`][crate::sql_macro::SqlMacro::to_sql] is pure Rust
+//! - **Interval conversions** — [`interval_to_micros`][crate::interval::interval_to_micros] is pure Rust
+//! - **Validation / scaffold** — [`validate`][crate::validate] and [`scaffold`][crate::scaffold] are pure Rust
+//! - **SQL-level results** — use [`InMemoryDb`] (requires `bundled-test` Cargo feature)
+//!
+//! # What requires E2E tests (SQLLogicTest)
+//!
+//! - FFI wiring correctness (entry point, callback signatures)
+//! - Function registration success (Pitfall P6: registration can fail silently)
+//! - NULL handling through real `DuckDB` NULL propagation
+//! - Multi-group aggregation results
+//! - Extension loading without crash
+//!
+//! See the [testing guide](https://quack-rs.com/testing) and `LESSONS.md` Pitfall P3 for details.
 //!
 //! # Why you need both unit tests AND E2E tests
 //!
-//! **Unit tests (this harness)** verify that your `MyState::update` and
+//! **Unit tests (this module)** verify that your `MyState::update` and
 //! `MyState::combine` methods produce correct results. They run fast and
 //! catch logical bugs.
 //!
@@ -27,7 +78,7 @@
 //!
 //! **Unit tests alone are insufficient. Always run E2E tests.**
 //!
-//! # Example
+//! # Example: testing aggregate logic
 //!
 //! ```rust
 //! use quack_rs::testing::AggregateTestHarness;
@@ -41,12 +92,6 @@
 //!     fn update(&mut self, value: i64) {
 //!         self.total += value;
 //!     }
-//!     fn combine(source: &Self, target: &mut Self) {
-//!         target.total += source.total;
-//!     }
-//!     fn finalize(&self) -> i64 {
-//!         self.total
-//!     }
 //! }
 //!
 //! let mut harness = AggregateTestHarness::<SumState>::new();
@@ -57,6 +102,64 @@
 //! let state = harness.finalize();
 //! assert_eq!(state.total, 35);
 //! ```
+//!
+//! # Example: testing callback output logic with mocks
+//!
+//! ```rust
+//! use quack_rs::testing::{MockVectorReader, MockVectorWriter};
+//!
+//! // Extract pure logic from the FFI callback into a testable function.
+//! fn double_values(reader: &MockVectorReader, writer: &mut MockVectorWriter) {
+//!     for i in 0..reader.row_count() {
+//!         if reader.is_valid(i) {
+//!             let v = reader.try_get_i64(i).unwrap_or(0);
+//!             writer.write_i64(i, v * 2);
+//!         } else {
+//!             writer.set_null(i);
+//!         }
+//!     }
+//! }
+//!
+//! let reader = MockVectorReader::from_i64s([Some(1), None, Some(5)]);
+//! let mut writer = MockVectorWriter::new(3);
+//! double_values(&reader, &mut writer);
+//!
+//! assert_eq!(writer.try_get_i64(0), Some(2));
+//! assert!(writer.is_null(1));
+//! assert_eq!(writer.try_get_i64(2), Some(10));
+//! ```
+//!
+//! # Example: testing registration with `MockRegistrar`
+//!
+//! ```rust
+//! use quack_rs::connection::Registrar;
+//! use quack_rs::testing::MockRegistrar;
+//! use quack_rs::scalar::ScalarFunctionBuilder;
+//! use quack_rs::types::TypeId;
+//! use quack_rs::error::ExtensionError;
+//!
+//! fn register_all(reg: &impl Registrar) -> Result<(), ExtensionError> {
+//!     let f = ScalarFunctionBuilder::new("my_fn")
+//!         .param(TypeId::BigInt)
+//!         .returns(TypeId::BigInt);
+//!     unsafe { reg.register_scalar(f) }
+//! }
+//!
+//! let mock = MockRegistrar::new();
+//! register_all(&mock).unwrap();
+//! assert!(mock.has_scalar("my_fn"));
+//! ```
 
 pub mod harness;
+pub mod mock_registrar;
+pub mod mock_vector;
+
+#[cfg(feature = "bundled-test")]
+pub mod in_memory_db;
+
 pub use harness::AggregateTestHarness;
+pub use mock_registrar::{CastRecord, MockRegistrar};
+pub use mock_vector::{MockDuckValue, MockVectorReader, MockVectorWriter};
+
+#[cfg(feature = "bundled-test")]
+pub use in_memory_db::InMemoryDb;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -583,3 +583,292 @@ fn scaffold_generated_code_compiles() {
         String::from_utf8_lossy(&output.stderr),
     );
 }
+
+// ---------------------------------------------------------------------------
+// MockVectorWriter / MockVectorReader tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mock_vector_writer_basic_write_and_read() {
+    use quack_rs::testing::{MockDuckValue, MockVectorWriter};
+
+    let mut w = MockVectorWriter::new(4);
+    w.write_i64(0, 42);
+    w.write_i64(1, -7);
+    w.set_null(2);
+    w.write_varchar(3, "hello");
+
+    assert_eq!(w.try_get_i64(0), Some(42));
+    assert_eq!(w.try_get_i64(1), Some(-7));
+    assert!(w.is_null(2));
+    assert_eq!(w.try_get_str(3), Some("hello"));
+    // Wrong type returns None
+    assert_eq!(w.try_get_i64(3), None);
+    assert!(matches!(w.get(0), Some(MockDuckValue::I64(42))));
+}
+
+#[test]
+fn mock_vector_writer_set_null_after_write() {
+    use quack_rs::testing::MockVectorWriter;
+
+    let mut w = MockVectorWriter::new(1);
+    w.write_i64(0, 100);
+    assert!(!w.is_null(0));
+    w.set_null(0);
+    assert!(w.is_null(0));
+    assert_eq!(w.try_get_i64(0), None);
+}
+
+#[test]
+fn mock_vector_writer_grows_beyond_initial_capacity() {
+    use quack_rs::testing::MockVectorWriter;
+
+    let mut w = MockVectorWriter::new(0);
+    w.write_i64(3, 99);
+    assert_eq!(w.len(), 4);
+    assert_eq!(w.try_get_i64(3), Some(99));
+    assert!(w.is_null(0));
+    assert!(w.is_null(1));
+    assert!(w.is_null(2));
+}
+
+#[test]
+fn mock_vector_writer_boolean_and_interval() {
+    use quack_rs::testing::MockVectorWriter;
+    use quack_rs::interval::DuckInterval;
+
+    let mut w = MockVectorWriter::new(2);
+    w.write_bool(0, true);
+    let iv = DuckInterval { months: 1, days: 2, micros: 3 };
+    w.write_interval(1, iv);
+
+    assert_eq!(w.try_get_bool(0), Some(true));
+    assert_eq!(w.try_get_interval(1), Some(iv));
+}
+
+#[test]
+fn mock_vector_reader_from_i64s() {
+    use quack_rs::testing::MockVectorReader;
+
+    let r = MockVectorReader::from_i64s([Some(10), None, Some(-5)]);
+    assert_eq!(r.row_count(), 3);
+    assert!(r.is_valid(0));
+    assert!(!r.is_valid(1));
+    assert!(r.is_valid(2));
+    assert_eq!(r.try_get_i64(0), Some(10));
+    assert_eq!(r.try_get_i64(1), None);
+    assert_eq!(r.try_get_i64(2), Some(-5));
+}
+
+#[test]
+fn mock_vector_reader_from_strs() {
+    use quack_rs::testing::MockVectorReader;
+
+    let r = MockVectorReader::from_strs([Some("alpha"), None, Some("beta")]);
+    assert_eq!(r.try_get_str(0), Some("alpha"));
+    assert_eq!(r.try_get_str(1), None);
+    assert_eq!(r.try_get_str(2), Some("beta"));
+    assert!(!r.is_valid(1));
+}
+
+#[test]
+fn mock_vector_reader_out_of_bounds() {
+    use quack_rs::testing::MockVectorReader;
+
+    let r = MockVectorReader::from_i64s([Some(1)]);
+    assert!(!r.is_valid(100));
+    assert_eq!(r.try_get_i64(100), None);
+}
+
+#[test]
+fn mock_vector_pattern_extract_and_test_logic() {
+    // Demonstrates the recommended pattern: extract callback logic into a
+    // pure-Rust function that can be called with MockVectorReader/Writer.
+    use quack_rs::testing::{MockVectorReader, MockVectorWriter};
+
+    fn clamp_values(
+        reader: &MockVectorReader,
+        writer: &mut MockVectorWriter,
+        lo: i64,
+        hi: i64,
+    ) {
+        for i in 0..reader.row_count() {
+            if reader.is_valid(i) {
+                let v = reader.try_get_i64(i).unwrap_or(0);
+                writer.write_i64(i, v.clamp(lo, hi));
+            } else {
+                writer.set_null(i);
+            }
+        }
+    }
+
+    let reader = MockVectorReader::from_i64s([Some(-5), Some(3), None, Some(15)]);
+    let mut writer = MockVectorWriter::new(4);
+    clamp_values(&reader, &mut writer, 0, 10);
+
+    assert_eq!(writer.try_get_i64(0), Some(0));
+    assert_eq!(writer.try_get_i64(1), Some(3));
+    assert!(writer.is_null(2));
+    assert_eq!(writer.try_get_i64(3), Some(10));
+}
+
+// ---------------------------------------------------------------------------
+// MockRegistrar tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mock_registrar_records_scalar_function() {
+    use quack_rs::connection::Registrar;
+    use quack_rs::scalar::ScalarFunctionBuilder;
+    use quack_rs::testing::MockRegistrar;
+    use quack_rs::types::TypeId;
+
+    let mock = MockRegistrar::new();
+    let b = ScalarFunctionBuilder::new("word_count")
+        .param(TypeId::Varchar)
+        .returns(TypeId::BigInt);
+    unsafe { mock.register_scalar(b).unwrap() };
+
+    assert!(mock.has_scalar("word_count"));
+    assert_eq!(mock.scalar_names(), vec!["word_count"]);
+    assert_eq!(mock.total_registrations(), 1);
+}
+
+#[test]
+fn mock_registrar_records_aggregate_function() {
+    use quack_rs::aggregate::AggregateFunctionBuilder;
+    use quack_rs::connection::Registrar;
+    use quack_rs::testing::MockRegistrar;
+    use quack_rs::types::TypeId;
+
+    let mock = MockRegistrar::new();
+    let b = AggregateFunctionBuilder::new("my_agg")
+        .param(TypeId::BigInt)
+        .returns(TypeId::BigInt);
+    unsafe { mock.register_aggregate(b).unwrap() };
+
+    assert!(mock.has_aggregate("my_agg"));
+    assert_eq!(mock.total_registrations(), 1);
+}
+
+#[test]
+fn mock_registrar_records_table_function() {
+    use quack_rs::connection::Registrar;
+    use quack_rs::table::TableFunctionBuilder;
+    use quack_rs::testing::MockRegistrar;
+
+    let mock = MockRegistrar::new();
+    let b = TableFunctionBuilder::new("my_table_fn");
+    unsafe { mock.register_table(b).unwrap() };
+
+    assert!(mock.has_table("my_table_fn"));
+    assert_eq!(mock.total_registrations(), 1);
+}
+
+#[test]
+fn mock_registrar_records_sql_macro() {
+    use quack_rs::connection::Registrar;
+    use quack_rs::sql_macro::SqlMacro;
+    use quack_rs::testing::MockRegistrar;
+
+    let mock = MockRegistrar::new();
+    let m = SqlMacro::scalar("clamp", &["x", "lo", "hi"], "greatest(lo, least(hi, x))").unwrap();
+    unsafe { mock.register_sql_macro(m).unwrap() };
+
+    assert!(mock.has_sql_macro("clamp"));
+    assert_eq!(mock.total_registrations(), 1);
+}
+
+#[test]
+fn mock_registrar_records_cast() {
+    use quack_rs::cast::CastFunctionBuilder;
+    use quack_rs::connection::Registrar;
+    use quack_rs::testing::{CastRecord, MockRegistrar};
+    use quack_rs::types::TypeId;
+
+    let mock = MockRegistrar::new();
+    let b = CastFunctionBuilder::new(TypeId::Varchar, TypeId::Integer);
+    unsafe { mock.register_cast(b).unwrap() };
+
+    let casts = mock.casts();
+    assert_eq!(casts.len(), 1);
+    assert_eq!(
+        casts[0],
+        CastRecord {
+            source: TypeId::Varchar,
+            target: TypeId::Integer,
+        }
+    );
+}
+
+#[test]
+fn mock_registrar_used_as_generic_registrar() {
+    // Demonstrates the core use case: passing MockRegistrar where &impl Registrar
+    // is expected, so registration functions can be unit-tested.
+    use quack_rs::connection::Registrar;
+    use quack_rs::error::ExtensionError;
+    use quack_rs::scalar::ScalarFunctionBuilder;
+    use quack_rs::sql_macro::SqlMacro;
+    use quack_rs::testing::MockRegistrar;
+    use quack_rs::types::TypeId;
+
+    fn register_all(reg: &impl Registrar) -> Result<(), ExtensionError> {
+        let upper = ScalarFunctionBuilder::new("upper_ext")
+            .param(TypeId::Varchar)
+            .returns(TypeId::Varchar);
+        let m = SqlMacro::scalar("pi", &[], "3.14159265358979").unwrap();
+        unsafe {
+            reg.register_scalar(upper)?;
+            reg.register_sql_macro(m)?;
+        }
+        Ok(())
+    }
+
+    let mock = MockRegistrar::new();
+    register_all(&mock).unwrap();
+
+    assert_eq!(mock.total_registrations(), 2);
+    assert!(mock.has_scalar("upper_ext"));
+    assert!(mock.has_sql_macro("pi"));
+    assert!(!mock.has_scalar("pi")); // pi is a macro, not a scalar
+}
+
+// ---------------------------------------------------------------------------
+// Builder name() accessor tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scalar_builder_name_accessor() {
+    use quack_rs::scalar::ScalarFunctionBuilder;
+    use quack_rs::types::TypeId;
+
+    let b = ScalarFunctionBuilder::new("my_scalar").returns(TypeId::BigInt);
+    assert_eq!(b.name(), "my_scalar");
+}
+
+#[test]
+fn aggregate_builder_name_accessor() {
+    use quack_rs::aggregate::AggregateFunctionBuilder;
+    use quack_rs::types::TypeId;
+
+    let b = AggregateFunctionBuilder::new("my_agg").returns(TypeId::BigInt);
+    assert_eq!(b.name(), "my_agg");
+}
+
+#[test]
+fn table_builder_name_accessor() {
+    use quack_rs::table::TableFunctionBuilder;
+
+    let b = TableFunctionBuilder::new("my_table");
+    assert_eq!(b.name(), "my_table");
+}
+
+#[test]
+fn cast_builder_source_target_accessors() {
+    use quack_rs::cast::CastFunctionBuilder;
+    use quack_rs::types::TypeId;
+
+    let b = CastFunctionBuilder::new(TypeId::Varchar, TypeId::Integer);
+    assert_eq!(b.source(), TypeId::Varchar);
+    assert_eq!(b.target(), TypeId::Integer);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -634,12 +634,16 @@ fn mock_vector_writer_grows_beyond_initial_capacity() {
 
 #[test]
 fn mock_vector_writer_boolean_and_interval() {
-    use quack_rs::testing::MockVectorWriter;
     use quack_rs::interval::DuckInterval;
+    use quack_rs::testing::MockVectorWriter;
 
     let mut w = MockVectorWriter::new(2);
     w.write_bool(0, true);
-    let iv = DuckInterval { months: 1, days: 2, micros: 3 };
+    let iv = DuckInterval {
+        months: 1,
+        days: 2,
+        micros: 3,
+    };
     w.write_interval(1, iv);
 
     assert_eq!(w.try_get_bool(0), Some(true));
@@ -686,12 +690,7 @@ fn mock_vector_pattern_extract_and_test_logic() {
     // pure-Rust function that can be called with MockVectorReader/Writer.
     use quack_rs::testing::{MockVectorReader, MockVectorWriter};
 
-    fn clamp_values(
-        reader: &MockVectorReader,
-        writer: &mut MockVectorWriter,
-        lo: i64,
-        hi: i64,
-    ) {
+    fn clamp_values(reader: &MockVectorReader, writer: &mut MockVectorWriter, lo: i64, hi: i64) {
         for i in 0..reader.row_count() {
             if reader.is_valid(i) {
                 let v = reader.try_get_i64(i).unwrap_or(0);


### PR DESCRIPTION
## Summary

This PR adds comprehensive mock testing utilities to enable unit testing of DuckDB extension code without a live DuckDB instance. It introduces `MockVectorWriter`, `MockVectorReader`, and `MockRegistrar` — in-memory implementations that replicate the interfaces of their real counterparts but store data in plain Rust collections. These tools address the architectural limitation where the `loadable-extension` dispatch table is uninitialized in `cargo test`, causing any DuckDB C API call to panic. The PR also adds `InMemoryDb` (behind `bundled-test` feature) for SQL-level integration tests, and updates documentation to explain the dispatch wall and recommended testing patterns.

## Type of change

- [x] New feature (non-breaking, adds functionality)
- [x] Documentation update

## Changes

### New modules
- **`src/testing/mock_vector.rs`** (580 lines): Implements `MockVectorWriter` and `MockVectorReader` with support for all major DuckDB types (integers, floats, booleans, strings, intervals). Includes convenience constructors (`from_i64s`, `from_strs`, etc.) and typed getters matching the real vector API.
- **`src/testing/mock_registrar.rs`** (382 lines): Implements `MockRegistrar` as a `Registrar` trait implementation that records function registrations without calling any DuckDB C API. Includes `CastRecord` type and inspection methods (`has_scalar`, `total_registrations`, etc.).
- **`src/testing/in_memory_db.rs`** (167 lines): Wraps `duckdb::Connection` for SQL-level testing via the bundled DuckDB crate (requires `bundled-test` feature). Provides `execute_batch`, `execute`, and `query_one` convenience methods.

### Builder introspection
Added `name()` and `source()`/`target()` accessor methods to:
- `ScalarFunctionBuilder` and `ScalarFunctionSetBuilder`
- `AggregateFunctionBuilder` and `AggregateFunctionSetBuilder`
- `TableFunctionBuilder`
- `CastFunctionBuilder`

These enable `MockRegistrar` to extract function names and cast types for recording.

### Documentation
- **`book/src/testing.md`**: Expanded with detailed explanation of the `loadable-extension` dispatch wall, architectural limitations, recommended patterns for extracting callback logic, and examples of using each mock type.
- **`src/testing/mod.rs`**: Completely rewritten module documentation with a comprehensive table of testing tools, explanation of the dispatch limitation, and guidance on what can/cannot be tested in `cargo test`.
- **`Cargo.toml`**: Added `bundled-test` feature (disabled by default) that enables `InMemoryDb` via the `duckdb` crate.

### Tests
Added 15 integration tests in `tests/integration_test.rs` covering:
- `MockVectorWriter`: basic write/read, NULL handling, capacity growth, boolean/interval types
- `MockVectorReader`: construction from typed slices, validity checks, out-of-bounds handling
- Pattern demonstration: extracting callback logic and testing with mocks
- `MockRegistrar`: recording scalar/aggregate/table functions, SQL macros, casts, and generic usage

## Rationale

The `loadable-extension` feature of `libduckdb-sys` intentionally avoids linking the DuckDB runtime, instead using a lazy dispatch table initialized only when DuckDB loads the extension. This makes `cargo test` impossible for any code touching the DuckDB C API. These mock types provide drop-in replacements for the most common testing scenarios:

1. **Callback logic** (`VectorReader`/`VectorWriter`): Extract pure Rust logic, test with mocks
2. **Registration** (`Registrar`): Verify the right functions are registered without a connection
3. **SQL macros**: Test SQL generation (pure Rust) or execution (via `InMemoryDb`)
4. **Aggregate state**: Already supported by `AggregateTestHarness`

This follows the recommended pattern of separating FFI wiring (tested via E2E/SQLLogicTest) from business logic (tested via unit tests with

https://claude.ai/code/session_01VNBMF7HBc8dTc2cVDKqDmQ