### PR TITLE
Add secrets, TLS config, and warning APIs for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration injection. HTTP-capable extensions (e.g., `duck_net`) implement
   this trait to supply custom CA bundles, client certificates for mTLS, or
   restricted cipher suites through a uniform interface. Uses `std::any::Any`
-  so `quack-rs` has no dependency on any specific TLS library.
+  so `quack-rs` has no dependency on any specific TLS library. Security
+  hardened: `client_config()` returns `Result` for fallible config creation,
+  `accepts_invalid_certs()` and `min_tls_version()` enable security auditing,
+  `config_type_name()` allows safe pre-downcast verification, and
+  `audit_tls_provider()` integrates with the `warning` module to automatically
+  flag CWE-295 (cert validation bypass) and CWE-327 (deprecated TLS versions).
+  Includes `TlsVersion` enum with `is_deprecated()` and `Ord` ordering.
 
 - **`warning` module** — structured security warning API with
   `ExtensionWarning`, `WarningSeverity` (Info/Low/Medium/High/Critical), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-03-31
+
+### Added
+
+- **`ExtensionError`: additional `From` impls** — `From<std::io::Error>`,
+  `From<std::ffi::NulError>`, and `From<std::fmt::Error>` allow the `?` operator
+  to propagate common error types directly in `register_all()` without
+  `.map_err()`. This eliminates the need for `panic!()` when operations like
+  tokio runtime allocation fail during extension initialization.
+
+- **`tls` module** — `TlsConfigProvider` trait for type-erased TLS client
+  configuration injection. HTTP-capable extensions (e.g., `duck_net`) implement
+  this trait to supply custom CA bundles, client certificates for mTLS, or
+  restricted cipher suites through a uniform interface. Uses `std::any::Any`
+  so `quack-rs` has no dependency on any specific TLS library.
+
+- **`warning` module** — structured security warning API with
+  `ExtensionWarning`, `WarningSeverity` (Info/Low/Medium/High/Critical), and
+  `WarningCollector`. Extensions that touch external resources emit warnings
+  with machine-readable codes and optional CWE identifiers. `WarningCollector`
+  is thread-safe (`Mutex`-backed) and supports `emit()`, `snapshot()`,
+  `drain()`, and `clear()`.
+
+- **`secrets` module** — `SecretsManager` trait and `SecretEntry` type for
+  bridging into DuckDB's native `CREATE SECRET` storage. Extensions implement
+  `SecretsManager` to provide `get_secret()`, `list_secrets()`, and
+  `remove_secret()` through a safe Rust interface. `SecretEntry` uses a builder
+  pattern with `with_provider()`, `with_scope()`, and `with_field()`.
+
+- **`StructWriter::child_list_vector(field_idx)`** — semantic alias for
+  `child_vector()` that makes the intent clear when a struct field has LIST
+  type. Returns the raw `duckdb_vector` handle for use with `ListVector`
+  methods (`reserve`, `set_entry`, `set_size`, `child_writer`, etc.).
+
+- **Prelude additions** — `TlsConfigProvider`, `ExtensionWarning`,
+  `WarningSeverity`, `WarningCollector`, `SecretEntry`, `SecretsManager`
+  re-exported from `quack_rs::prelude`.
+
 ## [0.11.0] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SecretsManager` to provide `get_secret()`, `list_secrets()`, and
   `remove_secret()` through a safe Rust interface. `SecretEntry` uses a builder
   pattern with `with_provider()`, `with_scope()`, and `with_field()`.
+  Security hardened: `Debug` redacts field values, `Drop` zeroizes sensitive
+  data via `write_volatile`, `PartialEq` intentionally omitted to prevent
+  timing side-channels, and fields are private with accessor methods.
 
 - **`StructWriter::child_list_vector(field_idx)`** — semantic alias for
   `child_vector()` that makes the intent clear when a struct field has LIST

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cc",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quack-rs"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Tom F. <tomf@tomtomtech.net>"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ and eliminates every rough edge, so you write **zero lines of C or C++**.
 | Replacement scans | Undocumented vtable + manual string allocation | `ReplacementScanBuilder` 4-method chain |
 | Complex types (STRUCT/LIST/MAP/ARRAY) | Manual offset arithmetic over child vectors | `StructVector`, `ListVector`, `MapVector`, `ArrayVector` helpers |
 | Complex param/return types | Raw `duckdb_create_logical_type` + manual lifecycle | `param_logical(LogicalType)` / `returns_logical(LogicalType)` on all builders |
+| Init error propagation | Forced to `panic!()` when runtime allocation fails | `ExtensionError` has `From<io::Error>` — use `?` directly |
+| TLS configuration | No standard way to inject custom TLS configs | `TlsConfigProvider` trait (type-erased, zero deps) |
+| Security warnings | Every extension re-invents warning infrastructure | `ExtensionWarning` + `WarningCollector` with CWE codes |
+| Secrets management | Custom in-memory secrets + DuckDB bridge per extension | `SecretsManager` trait + `SecretEntry` builder |
 | Extension naming | Rejected by DuckDB CI with no explanation | `validate_extension_name` catches issues before submission |
 | description.yml | No tooling to validate before submission | `validate_description_yml_str` validates the whole file |
 | New project setup | Hours of boilerplate + reading DuckDB internals | `generate_scaffold` produces all 11 required files |
@@ -117,7 +121,7 @@ See [`LESSONS.md`](./LESSONS.md) for full analysis of each pitfall.
 
 ```toml
 [dependencies]
-quack-rs = "0.11"
+quack-rs = "0.12"
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
 ```
 
@@ -303,6 +307,9 @@ append_metadata target/release/libmy_extension.so \
 | [`types`] | DuckDB type system wrappers | `TypeId`, `LogicalType`, `NullHandling` |
 | [`interval`] | INTERVAL ↔ microseconds conversion | `DuckInterval`, `interval_to_micros` |
 | [`error`] | FFI-safe error type | `ExtensionError`, `ExtResult<T>` |
+| [`tls`] | Type-erased TLS config provider for HTTP-capable extensions | `TlsConfigProvider` |
+| [`warning`] | Structured security warning API | `ExtensionWarning`, `WarningSeverity`, `WarningCollector` |
+| [`secrets`] | Secrets manager bridge trait | `SecretsManager`, `SecretEntry` |
 | [`config`] | RAII wrapper for DuckDB database configuration | `DbConfig` |
 | [`validate`] | Community extension compliance | All validators below |
 | [`validate::description_yml`] | description.yml parsing and validation | `parse_description_yml`, `DescriptionYml` |
@@ -345,6 +352,9 @@ append_metadata target/release/libmy_extension.so \
 [`types`]: https://docs.rs/quack-rs/latest/quack_rs/types/index.html
 [`interval`]: https://docs.rs/quack-rs/latest/quack_rs/interval/index.html
 [`error`]: https://docs.rs/quack-rs/latest/quack_rs/error/index.html
+[`tls`]: https://docs.rs/quack-rs/latest/quack_rs/tls/index.html
+[`warning`]: https://docs.rs/quack-rs/latest/quack_rs/warning/index.html
+[`secrets`]: https://docs.rs/quack-rs/latest/quack_rs/secrets/index.html
 [`config`]: https://docs.rs/quack-rs/latest/quack_rs/config/index.html
 [`validate`]: https://docs.rs/quack-rs/latest/quack_rs/validate/index.html
 [`validate::description_yml`]: https://docs.rs/quack-rs/latest/quack_rs/validate/description_yml/index.html
@@ -605,6 +615,13 @@ flowchart TB
     SYS["**libduckdb-sys** >=1.4.4, &lt;2<br/>DuckDB C Extension API<br/>headers only · no linked library"]:::ffi
 
     RT[("**DuckDB**<br/>Runtime")]:::duckdb
+
+    subgraph EXT ["Extension infrastructure"]
+        direction LR
+        TLS["**tls**<br/>TlsConfigProvider"]
+        WRN["**warning**<br/>ExtensionWarning · WarningCollector"]
+        SEC["**secrets**<br/>SecretsManager · SecretEntry"]
+    end
 
     subgraph DEV ["Dev-time utilities"]
         direction LR

--- a/book/src/concepts/errors.md
+++ b/book/src/concepts/errors.md
@@ -23,6 +23,19 @@ let e = ExtensionError::from_error(some_std_error);
 - `std::error::Error`
 - `Display`, `Debug`, `Clone`, `PartialEq`, `Eq`
 - `From<&str>`, `From<String>`, `From<Box<dyn Error>>`
+- `From<std::io::Error>`, `From<std::ffi::NulError>`, `From<std::fmt::Error>`
+
+The `From<std::io::Error>` impl is especially useful for extensions that
+allocate runtime resources (e.g., tokio) during initialization — the `?`
+operator works directly without `.map_err()`:
+
+```rust
+fn register_all(con: &Connection) -> Result<(), ExtensionError> {
+    let _rt = tokio::runtime::Runtime::new()?; // ← io::Error → ExtensionError
+    // ... register functions ...
+    Ok(())
+}
+```
 
 ---
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,6 +10,17 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-03-31
+
+### Added
+
+- **`ExtensionError` ergonomics** — `From<std::io::Error>`, `From<std::ffi::NulError>`, `From<std::fmt::Error>` for direct `?` operator usage in `register_all()`
+- **`tls` module** — `TlsConfigProvider` trait for type-erased TLS client configuration injection (no external deps)
+- **`warning` module** — `ExtensionWarning`, `WarningSeverity`, `WarningCollector` for structured security warnings with CWE codes
+- **`secrets` module** — `SecretsManager` trait and `SecretEntry` for bridging DuckDB's native `CREATE SECRET` storage
+- **`StructWriter::child_list_vector()`** — semantic alias for LIST-typed struct fields
+- **Prelude additions** — `TlsConfigProvider`, `ExtensionWarning`, `WarningSeverity`, `WarningCollector`, `SecretEntry`, `SecretsManager`
+
 ## [0.11.0] — 2026-03-30
 
 ### Added

--- a/src/error.rs
+++ b/src/error.rs
@@ -173,6 +173,33 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for ExtensionError {
     }
 }
 
+impl From<std::io::Error> for ExtensionError {
+    #[inline]
+    fn from(e: std::io::Error) -> Self {
+        Self {
+            message: e.to_string(),
+        }
+    }
+}
+
+impl From<std::ffi::NulError> for ExtensionError {
+    #[inline]
+    fn from(e: std::ffi::NulError) -> Self {
+        Self {
+            message: e.to_string(),
+        }
+    }
+}
+
+impl From<std::fmt::Error> for ExtensionError {
+    #[inline]
+    fn from(e: std::fmt::Error) -> Self {
+        Self {
+            message: e.to_string(),
+        }
+    }
+}
+
 /// Convenience type alias for `Result<T, ExtensionError>`.
 pub type ExtResult<T> = Result<T, ExtensionError>;
 
@@ -264,5 +291,35 @@ mod tests {
             Ok(())
         }
         assert_eq!(fails().unwrap_err().as_str(), "explicit error");
+    }
+
+    #[test]
+    fn from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err = ExtensionError::from(io_err);
+        assert_eq!(err.as_str(), "file not found");
+    }
+
+    #[test]
+    fn question_mark_with_io_error() {
+        fn fails() -> Result<(), ExtensionError> {
+            Err(std::io::Error::other("runtime init failed"))?;
+            Ok(())
+        }
+        assert_eq!(fails().unwrap_err().as_str(), "runtime init failed");
+    }
+
+    #[test]
+    fn from_nul_error() {
+        let nul_err = std::ffi::CString::new("hello\0world").unwrap_err();
+        let err = ExtensionError::from(nul_err);
+        assert!(!err.as_str().is_empty());
+    }
+
+    #[test]
+    fn from_fmt_error() {
+        let fmt_err = std::fmt::Error;
+        let err = ExtensionError::from(fmt_err);
+        assert!(!err.as_str().is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@
 //! | [`error`] | `ExtensionError` for FFI error propagation |
 //! | [`config`] | RAII wrapper for `DuckDB` database configuration |
 //! | [`value`] | RAII wrapper for `DuckDB` values with typed extraction |
+//! | [`tls`] | Type-erased TLS configuration provider for HTTP-capable extensions |
+//! | [`warning`] | Structured security warning API (`ExtensionWarning`, `WarningCollector`) |
+//! | [`secrets`] | Secrets manager bridge trait (`SecretsManager`, `SecretEntry`) |
 //! | [`validate`] | Community extension compliance validators |
 //! | [`validate::description_yml`] | Parse and validate `description.yml` metadata |
 //! | [`scaffold`] | Project generator for new extensions (no C++ glue needed) |
@@ -129,13 +132,16 @@ pub mod prelude;
 pub mod replacement_scan;
 pub mod scaffold;
 pub mod scalar;
+pub mod secrets;
 pub mod sql_macro;
 pub mod table;
 pub mod testing;
+pub mod tls;
 pub mod types;
 pub mod validate;
 pub mod value;
 pub mod vector;
+pub mod warning;
 
 // DuckDB 1.5.0+ modules — gated behind the `duckdb-1-5` feature flag.
 #[cfg(feature = "duckdb-1-5")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -64,6 +64,12 @@
 //! | [`interval_to_micros`] | `interval` module |
 //! | [`ExtensionError`] | `error` module |
 //! | [`ExtResult`] | `error` module |
+//! | [`SecretEntry`] | `secrets` module |
+//! | [`SecretsManager`] | `secrets` module |
+//! | [`TlsConfigProvider`] | `tls` module |
+//! | [`ExtensionWarning`] | `warning` module |
+//! | [`WarningCollector`] | `warning` module |
+//! | [`WarningSeverity`] | `warning` module |
 //! | [`DUCKDB_API_VERSION`] | crate root |
 //!
 //! # What is NOT included
@@ -164,6 +170,15 @@ pub use crate::interval::{interval_to_micros, DuckInterval};
 
 // Error
 pub use crate::error::{ExtResult, ExtensionError};
+
+// Secrets manager
+pub use crate::secrets::{SecretEntry, SecretsManager};
+
+// TLS config provider
+pub use crate::tls::TlsConfigProvider;
+
+// Warnings
+pub use crate::warning::{ExtensionWarning, WarningCollector, WarningSeverity};
 
 // API version constant
 pub use crate::DUCKDB_API_VERSION;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -67,6 +67,8 @@
 //! | [`SecretEntry`] | `secrets` module |
 //! | [`SecretsManager`] | `secrets` module |
 //! | [`TlsConfigProvider`] | `tls` module |
+//! | [`TlsVersion`] | `tls` module |
+//! | [`audit_tls_provider`] | `tls` module |
 //! | [`ExtensionWarning`] | `warning` module |
 //! | [`WarningCollector`] | `warning` module |
 //! | [`WarningSeverity`] | `warning` module |
@@ -175,7 +177,7 @@ pub use crate::error::{ExtResult, ExtensionError};
 pub use crate::secrets::{SecretEntry, SecretsManager};
 
 // TLS config provider
-pub use crate::tls::TlsConfigProvider;
+pub use crate::tls::{audit_tls_provider, TlsConfigProvider, TlsVersion};
 
 // Warnings
 pub use crate::warning::{ExtensionWarning, WarningCollector, WarningSeverity};

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -13,6 +13,21 @@
 //! [`SecretsManager`] is the trait that extensions implement to provide secret
 //! lookup. [`SecretEntry`] is the returned secret value.
 //!
+//! # Security considerations
+//!
+//! `SecretEntry` is designed to minimize accidental credential leakage:
+//!
+//! - **`Debug` redacts field values** — only field keys are shown, values are
+//!   replaced with `"[REDACTED]"`. Use [`get_field`][SecretEntry::get_field] to
+//!   access actual values in code.
+//! - **`Drop` zeroizes sensitive data** — all field values are overwritten with
+//!   zeros using [`std::ptr::write_volatile`] before deallocation, preventing
+//!   secrets from lingering in freed memory.
+//! - **No `PartialEq`** — prevents accidental non-constant-time comparisons of
+//!   secret material. Compare individual fields explicitly if needed.
+//! - **`Clone` is explicit** — cloning is supported but documented so that
+//!   callers are aware they are duplicating sensitive material in memory.
+//!
 //! # Example
 //!
 //! ```rust
@@ -26,13 +41,13 @@
 //! impl SecretsManager for MySecrets {
 //!     fn get_secret(&self, name: &str, secret_type: &str) -> Option<SecretEntry> {
 //!         self.entries.iter()
-//!             .find(|e| e.name == name && e.secret_type == secret_type)
+//!             .find(|e| e.name() == name && e.secret_type() == secret_type)
 //!             .cloned()
 //!     }
 //!
 //!     fn list_secrets(&self, secret_type: Option<&str>) -> Vec<SecretEntry> {
 //!         self.entries.iter()
-//!             .filter(|e| secret_type.is_none() || secret_type == Some(e.secret_type.as_str()))
+//!             .filter(|e| secret_type.is_none() || secret_type == Some(e.secret_type()))
 //!             .cloned()
 //!             .collect()
 //!     }
@@ -44,33 +59,28 @@
 //! ```
 
 use std::collections::HashMap;
+use std::fmt;
 
 /// A single secret entry retrieved from the secrets manager.
 ///
 /// Contains the secret's metadata and key-value pairs. The `fields` map holds
 /// the actual secret data (e.g., `"token"`, `"username"`, `"password"`,
 /// `"client_cert_path"`).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// # Security
+///
+/// - [`Debug`] output redacts all field values (shows keys only).
+/// - [`Drop`] zeroizes all field values before deallocation.
+/// - [`Clone`] is supported but creates a second copy of sensitive data in
+///   memory — use sparingly and drop clones promptly.
+/// - `PartialEq` / `Eq` are intentionally **not** implemented to prevent
+///   accidental non-constant-time comparisons of secret material.
 pub struct SecretEntry {
-    /// The name of the secret (as given in `CREATE SECRET name ...`).
-    pub name: String,
-
-    /// The secret type (e.g., `"bearer"`, `"s3"`, `"gcs"`, `"azure"`).
-    pub secret_type: String,
-
-    /// The provider that created this secret (e.g., `"config"`, `"credential_chain"`).
-    pub provider: String,
-
-    /// The scope/pattern this secret applies to (e.g., `"s3://my-bucket"`).
-    /// Empty string if unscoped.
-    pub scope: String,
-
-    /// Key-value pairs holding the secret data.
-    ///
-    /// Common keys include `"token"`, `"key_id"`, `"secret"`, `"region"`,
-    /// `"endpoint"`, `"account_name"`, etc. The exact keys depend on the
-    /// secret type.
-    pub fields: HashMap<String, String>,
+    name: String,
+    secret_type: String,
+    provider: String,
+    scope: String,
+    fields: HashMap<String, String>,
 }
 
 impl SecretEntry {
@@ -84,8 +94,8 @@ impl SecretEntry {
     /// let entry = SecretEntry::new("my_api_key", "bearer")
     ///     .with_provider("config")
     ///     .with_field("token", "sk-abc123");
-    /// assert_eq!(entry.name, "my_api_key");
-    /// assert_eq!(entry.fields.get("token").unwrap(), "sk-abc123");
+    /// assert_eq!(entry.name(), "my_api_key");
+    /// assert_eq!(entry.get_field("token"), Some("sk-abc123"));
     /// ```
     #[must_use]
     pub fn new(name: impl Into<String>, secret_type: impl Into<String>) -> Self {
@@ -96,6 +106,42 @@ impl SecretEntry {
             scope: String::new(),
             fields: HashMap::new(),
         }
+    }
+
+    /// Returns the name of this secret.
+    #[must_use]
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the secret type (e.g., `"bearer"`, `"s3"`, `"gcs"`).
+    #[must_use]
+    #[inline]
+    pub fn secret_type(&self) -> &str {
+        &self.secret_type
+    }
+
+    /// Returns the provider that created this secret.
+    #[must_use]
+    #[inline]
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// Returns the scope this secret applies to.
+    #[must_use]
+    #[inline]
+    pub fn scope(&self) -> &str {
+        &self.scope
+    }
+
+    /// Returns the field key names without exposing values.
+    ///
+    /// Use this for logging or diagnostics without leaking sensitive data.
+    #[must_use]
+    pub fn field_keys(&self) -> Vec<&str> {
+        self.fields.keys().map(String::as_str).collect()
     }
 
     /// Sets the provider for this secret entry.
@@ -124,6 +170,111 @@ impl SecretEntry {
     pub fn get_field(&self, key: &str) -> Option<&str> {
         self.fields.get(key).map(String::as_str)
     }
+
+    /// Returns the number of fields in this secret entry.
+    #[must_use]
+    #[inline]
+    pub fn field_count(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns `true` if this entry has no fields.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+/// Zeroize a `String`'s buffer using volatile writes, then clear it.
+///
+/// Uses [`std::ptr::write_volatile`] to ensure the compiler cannot elide the
+/// zeroing even if the memory is about to be freed. This is the standard
+/// approach used by the `zeroize` crate, implemented inline to avoid adding
+/// a dependency.
+fn zeroize_string(s: &mut String) {
+    // SAFETY: `as_mut_vec()` gives us mutable access to the String's backing
+    // buffer. We only write `0u8` bytes, which is valid UTF-8 (NUL chars).
+    // The string is cleared immediately after, so no invalid-UTF-8 state
+    // is observable.
+    unsafe {
+        for byte in s.as_mut_vec().iter_mut() {
+            std::ptr::write_volatile(byte, 0);
+        }
+    }
+    s.clear();
+}
+
+impl Drop for SecretEntry {
+    fn drop(&mut self) {
+        // Zeroize all field values (the sensitive material).
+        for value in self.fields.values_mut() {
+            zeroize_string(value);
+        }
+        // Zeroize field keys too — key names can reveal what credentials exist.
+        // HashMap doesn't expose mutable key access, so we drain and zeroize.
+        for (mut key, mut val) in self.fields.drain() {
+            zeroize_string(&mut key);
+            zeroize_string(&mut val);
+        }
+
+        // Zeroize metadata fields that may contain sensitive context.
+        zeroize_string(&mut self.provider);
+        zeroize_string(&mut self.scope);
+    }
+}
+
+impl Clone for SecretEntry {
+    /// Clones this secret entry, duplicating all sensitive material in memory.
+    ///
+    /// Callers should be aware that cloning creates a second copy of secret
+    /// values. Drop the clone as soon as it is no longer needed to minimize
+    /// the window during which sensitive data resides in memory.
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            secret_type: self.secret_type.clone(),
+            provider: self.provider.clone(),
+            scope: self.scope.clone(),
+            fields: self.fields.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for SecretEntry {
+    /// Formats the secret entry with field values redacted.
+    ///
+    /// Only field keys are shown; all values are replaced with `"[REDACTED]"`.
+    /// Use [`get_field`][SecretEntry::get_field] to access actual values in code.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let redacted_fields: HashMap<&str, &str> = self
+            .fields
+            .keys()
+            .map(|k| (k.as_str(), "[REDACTED]"))
+            .collect();
+
+        f.debug_struct("SecretEntry")
+            .field("name", &self.name)
+            .field("secret_type", &self.secret_type)
+            .field("provider", &self.provider)
+            .field("scope", &self.scope)
+            .field("fields", &redacted_fields)
+            .finish()
+    }
+}
+
+impl fmt::Display for SecretEntry {
+    /// Formats a human-readable summary without exposing any secret values.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Secret(name={:?}, type={:?}, provider={:?}, fields={})",
+            self.name,
+            self.secret_type,
+            self.provider,
+            self.fields.len()
+        )
+    }
 }
 
 /// Trait for accessing `DuckDB`'s secrets management system.
@@ -137,6 +288,15 @@ impl SecretEntry {
 ///
 /// Implementations must be safe to call from multiple threads. `DuckDB` may
 /// invoke extension callbacks concurrently.
+///
+/// # Security
+///
+/// Implementations should:
+/// - Never log secret field values (use [`SecretEntry::field_keys`] for
+///   diagnostics).
+/// - Ensure that `remove_secret` zeroizes the secret data, not just
+///   removes the reference.
+/// - Minimize the lifetime of [`SecretEntry`] clones.
 pub trait SecretsManager: Send + Sync {
     /// Retrieves a secret by name and type.
     ///
@@ -146,11 +306,18 @@ pub trait SecretsManager: Send + Sync {
     /// Lists all secrets, optionally filtered by type.
     ///
     /// If `secret_type` is `None`, all secrets are returned.
+    ///
+    /// # Security note
+    ///
+    /// The returned entries contain full secret values. Callers should avoid
+    /// storing or logging the result. For diagnostics, iterate and use
+    /// [`SecretEntry::field_keys`] instead of [`SecretEntry::get_field`].
     fn list_secrets(&self, secret_type: Option<&str>) -> Vec<SecretEntry>;
 
     /// Removes a secret by name and type.
     ///
     /// Returns `true` if the secret was found and removed, `false` otherwise.
+    /// Implementations should zeroize the secret data before deallocation.
     fn remove_secret(&self, name: &str, secret_type: &str) -> bool;
 }
 
@@ -166,28 +333,113 @@ mod tests {
             .with_field("token", "abc123")
             .with_field("refresh_token", "xyz789");
 
-        assert_eq!(entry.name, "test");
-        assert_eq!(entry.secret_type, "bearer");
-        assert_eq!(entry.provider, "config");
-        assert_eq!(entry.scope, "https://api.example.com");
+        assert_eq!(entry.name(), "test");
+        assert_eq!(entry.secret_type(), "bearer");
+        assert_eq!(entry.provider(), "config");
+        assert_eq!(entry.scope(), "https://api.example.com");
         assert_eq!(entry.get_field("token"), Some("abc123"));
         assert_eq!(entry.get_field("refresh_token"), Some("xyz789"));
         assert_eq!(entry.get_field("nonexistent"), None);
+        assert_eq!(entry.field_count(), 2);
+        assert!(!entry.is_empty());
     }
 
     #[test]
     fn secret_entry_new_defaults() {
         let entry = SecretEntry::new("s", "s3");
-        assert_eq!(entry.provider, "");
-        assert_eq!(entry.scope, "");
-        assert!(entry.fields.is_empty());
+        assert_eq!(entry.provider(), "");
+        assert_eq!(entry.scope(), "");
+        assert!(entry.is_empty());
+        assert_eq!(entry.field_count(), 0);
     }
 
     #[test]
-    fn secret_entry_clone_eq() {
+    #[allow(clippy::redundant_clone)]
+    fn secret_entry_clone() {
         let e1 = SecretEntry::new("a", "b").with_field("k", "v");
         let e2 = e1.clone();
-        assert_eq!(e1, e2);
+        assert_eq!(e2.name(), "a");
+        assert_eq!(e2.get_field("k"), Some("v"));
+    }
+
+    #[test]
+    fn debug_redacts_field_values() {
+        let entry =
+            SecretEntry::new("api_key", "bearer").with_field("token", "super-secret-value-12345");
+
+        let debug_output = format!("{entry:?}");
+
+        // The actual secret value must NOT appear in debug output.
+        assert!(
+            !debug_output.contains("super-secret-value-12345"),
+            "Debug output must not contain secret values: {debug_output}"
+        );
+        // The field key SHOULD appear (it's metadata, not the secret).
+        assert!(
+            debug_output.contains("token"),
+            "Debug should show field keys"
+        );
+        // The redaction marker should appear.
+        assert!(
+            debug_output.contains("[REDACTED]"),
+            "Debug should show [REDACTED] for values"
+        );
+    }
+
+    #[test]
+    fn display_does_not_leak_values() {
+        let entry =
+            SecretEntry::new("api_key", "bearer").with_field("token", "super-secret-value-12345");
+
+        let display_output = format!("{entry}");
+
+        assert!(
+            !display_output.contains("super-secret-value-12345"),
+            "Display must not contain secret values: {display_output}"
+        );
+        assert!(
+            display_output.contains("api_key"),
+            "Display should show the secret name"
+        );
+    }
+
+    #[test]
+    fn field_keys_returns_keys_only() {
+        let entry = SecretEntry::new("x", "y")
+            .with_field("token", "secret1")
+            .with_field("key_id", "secret2");
+
+        let keys = entry.field_keys();
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&"token"));
+        assert!(keys.contains(&"key_id"));
+    }
+
+    #[test]
+    fn drop_zeroizes_field_values() {
+        // We can't directly observe memory after drop, but we can verify
+        // zeroize_string works correctly on a standalone string.
+        let mut s = String::from("sensitive-data-here");
+        let ptr = s.as_ptr();
+        let len = s.len();
+
+        zeroize_string(&mut s);
+
+        assert!(s.is_empty(), "String should be empty after zeroize");
+        // Verify the original buffer was zeroed (the pointer is still valid
+        // because clear() doesn't deallocate).
+        let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+        assert!(
+            bytes.iter().all(|&b| b == 0),
+            "All bytes should be zero after zeroize"
+        );
+    }
+
+    #[test]
+    fn zeroize_empty_string_is_safe() {
+        let mut s = String::new();
+        zeroize_string(&mut s);
+        assert!(s.is_empty());
     }
 
     struct InMemorySecrets {
@@ -198,14 +450,14 @@ mod tests {
         fn get_secret(&self, name: &str, secret_type: &str) -> Option<SecretEntry> {
             self.entries
                 .iter()
-                .find(|e| e.name == name && e.secret_type == secret_type)
+                .find(|e| e.name() == name && e.secret_type() == secret_type)
                 .cloned()
         }
 
         fn list_secrets(&self, secret_type: Option<&str>) -> Vec<SecretEntry> {
             self.entries
                 .iter()
-                .filter(|e| secret_type.is_none() || secret_type == Some(e.secret_type.as_str()))
+                .filter(|e| secret_type.is_none() || secret_type == Some(e.secret_type()))
                 .cloned()
                 .collect()
         }
@@ -233,7 +485,7 @@ mod tests {
 
         let s3_only = mgr.list_secrets(Some("s3"));
         assert_eq!(s3_only.len(), 1);
-        assert_eq!(s3_only[0].name, "bucket");
+        assert_eq!(s3_only[0].name(), "bucket");
     }
 
     #[test]

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Secrets manager bridge for extensions.
+//!
+//! Extensions that access external services (HTTP APIs, databases, cloud storage)
+//! commonly need credentials. `DuckDB` provides a native secrets API via
+//! `CREATE SECRET`, and this module defines the Rust-side traits and types that
+//! extensions implement to bridge into that system.
+//!
+//! [`SecretsManager`] is the trait that extensions implement to provide secret
+//! lookup. [`SecretEntry`] is the returned secret value.
+//!
+//! # Example
+//!
+//! ```rust
+//! use quack_rs::secrets::{SecretEntry, SecretsManager};
+//!
+//! struct MySecrets {
+//!     // In practice, backed by DuckDB's CREATE SECRET storage
+//!     entries: Vec<SecretEntry>,
+//! }
+//!
+//! impl SecretsManager for MySecrets {
+//!     fn get_secret(&self, name: &str, secret_type: &str) -> Option<SecretEntry> {
+//!         self.entries.iter()
+//!             .find(|e| e.name == name && e.secret_type == secret_type)
+//!             .cloned()
+//!     }
+//!
+//!     fn list_secrets(&self, secret_type: Option<&str>) -> Vec<SecretEntry> {
+//!         self.entries.iter()
+//!             .filter(|e| secret_type.is_none() || secret_type == Some(e.secret_type.as_str()))
+//!             .cloned()
+//!             .collect()
+//!     }
+//!
+//!     fn remove_secret(&self, _name: &str, _secret_type: &str) -> bool {
+//!         false // read-only example
+//!     }
+//! }
+//! ```
+
+use std::collections::HashMap;
+
+/// A single secret entry retrieved from the secrets manager.
+///
+/// Contains the secret's metadata and key-value pairs. The `fields` map holds
+/// the actual secret data (e.g., `"token"`, `"username"`, `"password"`,
+/// `"client_cert_path"`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretEntry {
+    /// The name of the secret (as given in `CREATE SECRET name ...`).
+    pub name: String,
+
+    /// The secret type (e.g., `"bearer"`, `"s3"`, `"gcs"`, `"azure"`).
+    pub secret_type: String,
+
+    /// The provider that created this secret (e.g., `"config"`, `"credential_chain"`).
+    pub provider: String,
+
+    /// The scope/pattern this secret applies to (e.g., `"s3://my-bucket"`).
+    /// Empty string if unscoped.
+    pub scope: String,
+
+    /// Key-value pairs holding the secret data.
+    ///
+    /// Common keys include `"token"`, `"key_id"`, `"secret"`, `"region"`,
+    /// `"endpoint"`, `"account_name"`, etc. The exact keys depend on the
+    /// secret type.
+    pub fields: HashMap<String, String>,
+}
+
+impl SecretEntry {
+    /// Creates a new `SecretEntry` with the given name and type.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use quack_rs::secrets::SecretEntry;
+    ///
+    /// let entry = SecretEntry::new("my_api_key", "bearer")
+    ///     .with_provider("config")
+    ///     .with_field("token", "sk-abc123");
+    /// assert_eq!(entry.name, "my_api_key");
+    /// assert_eq!(entry.fields.get("token").unwrap(), "sk-abc123");
+    /// ```
+    #[must_use]
+    pub fn new(name: impl Into<String>, secret_type: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            secret_type: secret_type.into(),
+            provider: String::new(),
+            scope: String::new(),
+            fields: HashMap::new(),
+        }
+    }
+
+    /// Sets the provider for this secret entry.
+    #[must_use]
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = provider.into();
+        self
+    }
+
+    /// Sets the scope for this secret entry.
+    #[must_use]
+    pub fn with_scope(mut self, scope: impl Into<String>) -> Self {
+        self.scope = scope.into();
+        self
+    }
+
+    /// Adds a key-value field to this secret entry.
+    #[must_use]
+    pub fn with_field(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    /// Returns the value of a field, if present.
+    #[must_use]
+    pub fn get_field(&self, key: &str) -> Option<&str> {
+        self.fields.get(key).map(String::as_str)
+    }
+}
+
+/// Trait for accessing `DuckDB`'s secrets management system.
+///
+/// Extensions implement this trait to provide a safe Rust interface over
+/// `DuckDB`'s native `CREATE SECRET` / `DROP SECRET` storage. A typical
+/// implementation wraps `DuckDB`'s C API or maintains an in-memory cache
+/// synchronized with the `DuckDB` catalog.
+///
+/// # Thread safety
+///
+/// Implementations must be safe to call from multiple threads. `DuckDB` may
+/// invoke extension callbacks concurrently.
+pub trait SecretsManager: Send + Sync {
+    /// Retrieves a secret by name and type.
+    ///
+    /// Returns `None` if no matching secret exists.
+    fn get_secret(&self, name: &str, secret_type: &str) -> Option<SecretEntry>;
+
+    /// Lists all secrets, optionally filtered by type.
+    ///
+    /// If `secret_type` is `None`, all secrets are returned.
+    fn list_secrets(&self, secret_type: Option<&str>) -> Vec<SecretEntry>;
+
+    /// Removes a secret by name and type.
+    ///
+    /// Returns `true` if the secret was found and removed, `false` otherwise.
+    fn remove_secret(&self, name: &str, secret_type: &str) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_entry_builder() {
+        let entry = SecretEntry::new("test", "bearer")
+            .with_provider("config")
+            .with_scope("https://api.example.com")
+            .with_field("token", "abc123")
+            .with_field("refresh_token", "xyz789");
+
+        assert_eq!(entry.name, "test");
+        assert_eq!(entry.secret_type, "bearer");
+        assert_eq!(entry.provider, "config");
+        assert_eq!(entry.scope, "https://api.example.com");
+        assert_eq!(entry.get_field("token"), Some("abc123"));
+        assert_eq!(entry.get_field("refresh_token"), Some("xyz789"));
+        assert_eq!(entry.get_field("nonexistent"), None);
+    }
+
+    #[test]
+    fn secret_entry_new_defaults() {
+        let entry = SecretEntry::new("s", "s3");
+        assert_eq!(entry.provider, "");
+        assert_eq!(entry.scope, "");
+        assert!(entry.fields.is_empty());
+    }
+
+    #[test]
+    fn secret_entry_clone_eq() {
+        let e1 = SecretEntry::new("a", "b").with_field("k", "v");
+        let e2 = e1.clone();
+        assert_eq!(e1, e2);
+    }
+
+    struct InMemorySecrets {
+        entries: Vec<SecretEntry>,
+    }
+
+    impl SecretsManager for InMemorySecrets {
+        fn get_secret(&self, name: &str, secret_type: &str) -> Option<SecretEntry> {
+            self.entries
+                .iter()
+                .find(|e| e.name == name && e.secret_type == secret_type)
+                .cloned()
+        }
+
+        fn list_secrets(&self, secret_type: Option<&str>) -> Vec<SecretEntry> {
+            self.entries
+                .iter()
+                .filter(|e| secret_type.is_none() || secret_type == Some(e.secret_type.as_str()))
+                .cloned()
+                .collect()
+        }
+
+        fn remove_secret(&self, _name: &str, _secret_type: &str) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn in_memory_secrets_manager() {
+        let mgr = InMemorySecrets {
+            entries: vec![
+                SecretEntry::new("api_key", "bearer").with_field("token", "t1"),
+                SecretEntry::new("bucket", "s3").with_field("key_id", "k1"),
+            ],
+        };
+
+        assert!(mgr.get_secret("api_key", "bearer").is_some());
+        assert!(mgr.get_secret("api_key", "s3").is_none());
+        assert!(mgr.get_secret("missing", "bearer").is_none());
+
+        let all = mgr.list_secrets(None);
+        assert_eq!(all.len(), 2);
+
+        let s3_only = mgr.list_secrets(Some("s3"));
+        assert_eq!(s3_only.len(), 1);
+        assert_eq!(s3_only[0].name, "bucket");
+    }
+
+    #[test]
+    fn secrets_manager_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<InMemorySecrets>();
+    }
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -18,32 +18,102 @@
 //! implementing extension downcasts the returned `Arc<dyn Any>` to its concrete
 //! config type.
 //!
+//! # Security requirements for implementors
+//!
+//! Implementations **must**:
+//!
+//! - Return `false` from [`accepts_invalid_certs`][TlsConfigProvider::accepts_invalid_certs]
+//!   unless explicitly configured otherwise by the user. Certificate validation
+//!   bypass (CWE-295) should never be the default.
+//! - Return [`TlsVersion::Tls12`] or higher from
+//!   [`min_tls_version`][TlsConfigProvider::min_tls_version]. TLS 1.0 and 1.1
+//!   are deprecated ([RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996)).
+//! - Emit an [`ExtensionWarning`][crate::warning::ExtensionWarning] via
+//!   [`WarningCollector`][crate::warning::WarningCollector] when certificate
+//!   validation is disabled or when using a TLS version below 1.2.
+//!
 //! # Example
 //!
 //! ```rust
-//! use quack_rs::tls::TlsConfigProvider;
+//! use quack_rs::tls::{TlsConfigProvider, TlsVersion};
+//! use quack_rs::error::ExtensionError;
 //! use std::any::Any;
 //! use std::sync::Arc;
 //!
-//! // In your extension crate (which depends on rustls):
 //! struct MyTlsProvider {
-//!     // config: Arc<rustls::ClientConfig>,
-//!     config: Arc<String>, // placeholder for illustration
+//!     // In practice: Arc<rustls::ClientConfig>
+//!     config: Arc<String>,
+//!     mtls_enabled: bool,
 //! }
 //!
 //! impl TlsConfigProvider for MyTlsProvider {
-//!     fn client_config(&self) -> Arc<dyn Any + Send + Sync> {
-//!         self.config.clone()
+//!     fn client_config(&self) -> Result<Arc<dyn Any + Send + Sync>, ExtensionError> {
+//!         Ok(self.config.clone())
 //!     }
 //!
 //!     fn provider_name(&self) -> &str {
 //!         "my-extension-tls"
+//!     }
+//!
+//!     fn config_type_name(&self) -> &str {
+//!         "String" // In practice: "rustls::ClientConfig"
+//!     }
+//!
+//!     fn min_tls_version(&self) -> TlsVersion {
+//!         TlsVersion::Tls12
+//!     }
+//!
+//!     fn supports_mtls(&self) -> bool {
+//!         self.mtls_enabled
+//!     }
+//!
+//!     fn accepts_invalid_certs(&self) -> bool {
+//!         false
 //!     }
 //! }
 //! ```
 
 use std::any::Any;
 use std::sync::Arc;
+
+use crate::error::ExtensionError;
+
+/// Minimum TLS protocol version supported by a [`TlsConfigProvider`].
+///
+/// Used for security auditing and warning generation. Providers that allow
+/// versions below [`Tls12`][TlsVersion::Tls12] should emit a warning via
+/// [`WarningCollector`][crate::warning::WarningCollector].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TlsVersion {
+    /// TLS 1.0 — **deprecated** per [RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996).
+    Tls10,
+    /// TLS 1.1 — **deprecated** per [RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996).
+    Tls11,
+    /// TLS 1.2 — minimum recommended version.
+    Tls12,
+    /// TLS 1.3 — preferred version.
+    Tls13,
+}
+
+impl TlsVersion {
+    /// Returns `true` if this version is considered deprecated (TLS 1.0 or 1.1).
+    #[must_use]
+    #[inline]
+    pub const fn is_deprecated(self) -> bool {
+        matches!(self, Self::Tls10 | Self::Tls11)
+    }
+}
+
+impl std::fmt::Display for TlsVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tls10 => f.write_str("TLS 1.0"),
+            Self::Tls11 => f.write_str("TLS 1.1"),
+            Self::Tls12 => f.write_str("TLS 1.2"),
+            Self::Tls13 => f.write_str("TLS 1.3"),
+        }
+    }
+}
 
 /// A type-erased provider of TLS client configuration.
 ///
@@ -54,72 +124,325 @@ use std::sync::Arc;
 /// # Downcasting
 ///
 /// The returned `Arc<dyn Any + Send + Sync>` should be downcast by the
-/// consumer to the concrete config type. For example, an extension using
-/// `rustls` would do:
+/// consumer to the concrete config type. Use [`config_type_name`][Self::config_type_name]
+/// to verify the expected type before downcasting, and handle `None` from
+/// [`downcast_ref`][Any::downcast_ref] gracefully (never use `.expect()` or
+/// `.unwrap()` in FFI callback contexts — see Pitfall L3).
 ///
 /// ```rust,no_run
 /// use std::any::Any;
 /// use std::sync::Arc;
+/// use quack_rs::error::ExtensionError;
 ///
-/// fn use_config(config: Arc<dyn Any + Send + Sync>) {
+/// fn use_config(config: Arc<dyn Any + Send + Sync>) -> Result<(), ExtensionError> {
 ///     // let rustls_config = config.downcast_ref::<rustls::ClientConfig>()
-///     //     .expect("expected rustls ClientConfig");
+///     //     .ok_or(ExtensionError::new("expected rustls::ClientConfig"))?;
+///     Ok(())
 /// }
 /// ```
+///
+/// # Security
+///
+/// See the [module-level documentation][crate::tls] for security requirements.
+/// Implementations that bypass certificate validation or allow deprecated TLS
+/// versions should clearly document this and emit warnings.
 pub trait TlsConfigProvider: Send + Sync {
     /// Returns the TLS client configuration as a type-erased `Arc`.
     ///
     /// Implementations should return an `Arc` wrapping their concrete TLS
     /// config type (e.g., `Arc<rustls::ClientConfig>`).
-    fn client_config(&self) -> Arc<dyn Any + Send + Sync>;
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ExtensionError`] if the configuration cannot be created
+    /// (e.g., certificate file not found, invalid key format, expired CA).
+    fn client_config(&self) -> Result<Arc<dyn Any + Send + Sync>, ExtensionError>;
 
     /// Returns a human-readable name for this TLS provider.
     ///
-    /// Used in diagnostics and warning messages.
+    /// Used in diagnostics, warning messages, and error context.
     fn provider_name(&self) -> &str;
+
+    /// Returns the concrete type name of the config returned by [`client_config`][Self::client_config].
+    ///
+    /// This allows consumers to verify they have the right provider before
+    /// attempting a downcast. For example, a `rustls`-based provider would
+    /// return `"rustls::ClientConfig"`.
+    fn config_type_name(&self) -> &str;
+
+    /// Returns the minimum TLS protocol version this config allows.
+    ///
+    /// Implementations should return [`TlsVersion::Tls12`] or higher.
+    /// Returning a deprecated version ([`TlsVersion::Tls10`] or
+    /// [`TlsVersion::Tls11`]) should trigger a warning via
+    /// [`WarningCollector`][crate::warning::WarningCollector].
+    fn min_tls_version(&self) -> TlsVersion;
+
+    /// Returns `true` if this config includes a client certificate for mTLS.
+    fn supports_mtls(&self) -> bool;
+
+    /// Returns `true` if this config accepts invalid (self-signed, expired,
+    /// or hostname-mismatched) server certificates.
+    ///
+    /// # Security
+    ///
+    /// This should return `false` by default. Returning `true` disables
+    /// server certificate validation (CWE-295: Improper Certificate
+    /// Validation) and should **only** be enabled when explicitly requested
+    /// by the user (e.g., via a `SET` variable or connection parameter).
+    ///
+    /// When this returns `true`, the extension should emit an
+    /// [`ExtensionWarning`][crate::warning::ExtensionWarning] with
+    /// `code: "TLS_NO_VERIFY"`, `severity: High`, and `cwe: Some(295)`.
+    fn accepts_invalid_certs(&self) -> bool;
+}
+
+/// Validates a [`TlsConfigProvider`] and returns a list of security concerns.
+///
+/// This is a convenience function that checks common misconfigurations and
+/// returns human-readable warning messages. Extensions can call this during
+/// initialization and feed the results into a
+/// [`WarningCollector`][crate::warning::WarningCollector].
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use quack_rs::tls::audit_tls_provider;
+/// use quack_rs::warning::{WarningCollector, ExtensionWarning, WarningSeverity};
+///
+/// // let warnings = audit_tls_provider(&my_provider);
+/// // let collector = WarningCollector::new();
+/// // for w in warnings {
+/// //     collector.emit(w);
+/// // }
+/// ```
+#[must_use]
+pub fn audit_tls_provider(
+    provider: &dyn TlsConfigProvider,
+) -> Vec<crate::warning::ExtensionWarning> {
+    let mut warnings = Vec::new();
+
+    if provider.accepts_invalid_certs() {
+        warnings.push(crate::warning::ExtensionWarning {
+            code: "TLS_NO_VERIFY",
+            severity: crate::warning::WarningSeverity::High,
+            message: format!(
+                "TLS provider {:?} has certificate verification disabled",
+                provider.provider_name()
+            ),
+            cwe: Some(295),
+        });
+    }
+
+    let min_version = provider.min_tls_version();
+    if min_version.is_deprecated() {
+        warnings.push(crate::warning::ExtensionWarning {
+            code: "TLS_DEPRECATED_VERSION",
+            severity: crate::warning::WarningSeverity::Medium,
+            message: format!(
+                "TLS provider {:?} allows deprecated {} (RFC 8996)",
+                provider.provider_name(),
+                min_version,
+            ),
+            cwe: Some(327), // CWE-327: Use of a Broken or Risky Cryptographic Algorithm
+        });
+    }
+
+    warnings
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    struct TestProvider {
+    struct SecureProvider {
         config: Arc<String>,
     }
 
     #[allow(clippy::unnecessary_literal_bound)]
-    impl TlsConfigProvider for TestProvider {
-        fn client_config(&self) -> Arc<dyn Any + Send + Sync> {
-            self.config.clone()
+    impl TlsConfigProvider for SecureProvider {
+        fn client_config(&self) -> Result<Arc<dyn Any + Send + Sync>, ExtensionError> {
+            Ok(self.config.clone())
         }
 
         fn provider_name(&self) -> &str {
-            "test-tls"
+            "test-secure"
+        }
+
+        fn config_type_name(&self) -> &str {
+            "String"
+        }
+
+        fn min_tls_version(&self) -> TlsVersion {
+            TlsVersion::Tls12
+        }
+
+        fn supports_mtls(&self) -> bool {
+            false
+        }
+
+        fn accepts_invalid_certs(&self) -> bool {
+            false
+        }
+    }
+
+    struct InsecureProvider;
+
+    #[allow(clippy::unnecessary_literal_bound)]
+    impl TlsConfigProvider for InsecureProvider {
+        fn client_config(&self) -> Result<Arc<dyn Any + Send + Sync>, ExtensionError> {
+            Ok(Arc::new(42u32))
+        }
+
+        fn provider_name(&self) -> &str {
+            "test-insecure"
+        }
+
+        fn config_type_name(&self) -> &str {
+            "u32"
+        }
+
+        fn min_tls_version(&self) -> TlsVersion {
+            TlsVersion::Tls10
+        }
+
+        fn supports_mtls(&self) -> bool {
+            false
+        }
+
+        fn accepts_invalid_certs(&self) -> bool {
+            true
+        }
+    }
+
+    struct FailingProvider;
+
+    #[allow(clippy::unnecessary_literal_bound)]
+    impl TlsConfigProvider for FailingProvider {
+        fn client_config(&self) -> Result<Arc<dyn Any + Send + Sync>, ExtensionError> {
+            Err(ExtensionError::new("certificate file not found"))
+        }
+
+        fn provider_name(&self) -> &str {
+            "test-failing"
+        }
+
+        fn config_type_name(&self) -> &str {
+            "never"
+        }
+
+        fn min_tls_version(&self) -> TlsVersion {
+            TlsVersion::Tls13
+        }
+
+        fn supports_mtls(&self) -> bool {
+            true
+        }
+
+        fn accepts_invalid_certs(&self) -> bool {
+            false
         }
     }
 
     #[test]
-    fn provider_returns_config() {
-        let provider = TestProvider {
+    fn secure_provider_returns_config() {
+        let provider = SecureProvider {
             config: Arc::new("test-config".to_string()),
         };
-        let config = provider.client_config();
+        let config = provider.client_config().unwrap();
         let s = config.downcast_ref::<String>().unwrap();
         assert_eq!(s, "test-config");
     }
 
     #[test]
-    fn provider_name() {
-        let provider = TestProvider {
+    fn secure_provider_metadata() {
+        let provider = SecureProvider {
             config: Arc::new(String::new()),
         };
-        assert_eq!(provider.provider_name(), "test-tls");
+        assert_eq!(provider.provider_name(), "test-secure");
+        assert_eq!(provider.config_type_name(), "String");
+        assert_eq!(provider.min_tls_version(), TlsVersion::Tls12);
+        assert!(!provider.supports_mtls());
+        assert!(!provider.accepts_invalid_certs());
+    }
+
+    #[test]
+    fn failing_provider_returns_error() {
+        let provider = FailingProvider;
+        let err = provider.client_config().unwrap_err();
+        assert_eq!(err.as_str(), "certificate file not found");
+        assert!(provider.supports_mtls());
+    }
+
+    #[test]
+    fn downcast_wrong_type_returns_none() {
+        let provider = SecureProvider {
+            config: Arc::new("hello".to_string()),
+        };
+        let config = provider.client_config().unwrap();
+        // Trying to downcast String to u32 should return None, not panic.
+        assert!(config.downcast_ref::<u32>().is_none());
+    }
+
+    #[test]
+    fn audit_secure_provider_no_warnings() {
+        let provider = SecureProvider {
+            config: Arc::new(String::new()),
+        };
+        let warnings = audit_tls_provider(&provider);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn audit_insecure_provider_flags_issues() {
+        let provider = InsecureProvider;
+        let warnings = audit_tls_provider(&provider);
+
+        assert_eq!(warnings.len(), 2);
+
+        // Should flag invalid cert acceptance (CWE-295).
+        let cert_warning = warnings.iter().find(|w| w.code == "TLS_NO_VERIFY");
+        assert!(cert_warning.is_some());
+        assert_eq!(cert_warning.unwrap().cwe, Some(295));
+        assert_eq!(
+            cert_warning.unwrap().severity,
+            crate::warning::WarningSeverity::High
+        );
+
+        // Should flag deprecated TLS version (CWE-327).
+        let version_warning = warnings.iter().find(|w| w.code == "TLS_DEPRECATED_VERSION");
+        assert!(version_warning.is_some());
+        assert_eq!(version_warning.unwrap().cwe, Some(327));
+        assert!(version_warning.unwrap().message.contains("TLS 1.0"));
+    }
+
+    #[test]
+    fn tls_version_ordering() {
+        assert!(TlsVersion::Tls10 < TlsVersion::Tls11);
+        assert!(TlsVersion::Tls11 < TlsVersion::Tls12);
+        assert!(TlsVersion::Tls12 < TlsVersion::Tls13);
+    }
+
+    #[test]
+    fn tls_version_deprecated() {
+        assert!(TlsVersion::Tls10.is_deprecated());
+        assert!(TlsVersion::Tls11.is_deprecated());
+        assert!(!TlsVersion::Tls12.is_deprecated());
+        assert!(!TlsVersion::Tls13.is_deprecated());
+    }
+
+    #[test]
+    fn tls_version_display() {
+        assert_eq!(TlsVersion::Tls10.to_string(), "TLS 1.0");
+        assert_eq!(TlsVersion::Tls11.to_string(), "TLS 1.1");
+        assert_eq!(TlsVersion::Tls12.to_string(), "TLS 1.2");
+        assert_eq!(TlsVersion::Tls13.to_string(), "TLS 1.3");
     }
 
     #[test]
     fn provider_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<TestProvider>();
+        assert_send_sync::<SecureProvider>();
     }
 
     #[test]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -126,7 +126,7 @@ impl std::fmt::Display for TlsVersion {
 /// The returned `Arc<dyn Any + Send + Sync>` should be downcast by the
 /// consumer to the concrete config type. Use [`config_type_name`][Self::config_type_name]
 /// to verify the expected type before downcasting, and handle `None` from
-/// [`downcast_ref`][Any::downcast_ref] gracefully (never use `.expect()` or
+/// `downcast_ref` gracefully (never use `.expect()` or
 /// `.unwrap()` in FFI callback contexts — see Pitfall L3).
 ///
 /// ```rust,no_run

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Type-erased TLS configuration provider for HTTP-capable extensions.
+//!
+//! Extensions that make outbound HTTPS connections (e.g., `duck_net`) need a way
+//! to inject custom TLS configurations — client certificates for mTLS, custom CA
+//! bundles, or restricted cipher suites. This module provides the
+//! [`TlsConfigProvider`] trait so that extensions can supply their TLS setup
+//! through a uniform interface, regardless of which TLS library they use.
+//!
+//! # Design
+//!
+//! The trait is **type-erased** via [`std::any::Any`] so that `quack-rs` does not
+//! depend on any specific TLS library (e.g., `rustls`, `native-tls`). The
+//! implementing extension downcasts the returned `Arc<dyn Any>` to its concrete
+//! config type.
+//!
+//! # Example
+//!
+//! ```rust
+//! use quack_rs::tls::TlsConfigProvider;
+//! use std::any::Any;
+//! use std::sync::Arc;
+//!
+//! // In your extension crate (which depends on rustls):
+//! struct MyTlsProvider {
+//!     // config: Arc<rustls::ClientConfig>,
+//!     config: Arc<String>, // placeholder for illustration
+//! }
+//!
+//! impl TlsConfigProvider for MyTlsProvider {
+//!     fn client_config(&self) -> Arc<dyn Any + Send + Sync> {
+//!         self.config.clone()
+//!     }
+//!
+//!     fn provider_name(&self) -> &str {
+//!         "my-extension-tls"
+//!     }
+//! }
+//! ```
+
+use std::any::Any;
+use std::sync::Arc;
+
+/// A type-erased provider of TLS client configuration.
+///
+/// Extensions that make outbound HTTPS connections implement this trait to
+/// supply their TLS setup (client certificates, custom CA bundles, etc.)
+/// without coupling `quack-rs` to a specific TLS library.
+///
+/// # Downcasting
+///
+/// The returned `Arc<dyn Any + Send + Sync>` should be downcast by the
+/// consumer to the concrete config type. For example, an extension using
+/// `rustls` would do:
+///
+/// ```rust,no_run
+/// use std::any::Any;
+/// use std::sync::Arc;
+///
+/// fn use_config(config: Arc<dyn Any + Send + Sync>) {
+///     // let rustls_config = config.downcast_ref::<rustls::ClientConfig>()
+///     //     .expect("expected rustls ClientConfig");
+/// }
+/// ```
+pub trait TlsConfigProvider: Send + Sync {
+    /// Returns the TLS client configuration as a type-erased `Arc`.
+    ///
+    /// Implementations should return an `Arc` wrapping their concrete TLS
+    /// config type (e.g., `Arc<rustls::ClientConfig>`).
+    fn client_config(&self) -> Arc<dyn Any + Send + Sync>;
+
+    /// Returns a human-readable name for this TLS provider.
+    ///
+    /// Used in diagnostics and warning messages.
+    fn provider_name(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestProvider {
+        config: Arc<String>,
+    }
+
+    #[allow(clippy::unnecessary_literal_bound)]
+    impl TlsConfigProvider for TestProvider {
+        fn client_config(&self) -> Arc<dyn Any + Send + Sync> {
+            self.config.clone()
+        }
+
+        fn provider_name(&self) -> &str {
+            "test-tls"
+        }
+    }
+
+    #[test]
+    fn provider_returns_config() {
+        let provider = TestProvider {
+            config: Arc::new("test-config".to_string()),
+        };
+        let config = provider.client_config();
+        let s = config.downcast_ref::<String>().unwrap();
+        assert_eq!(s, "test-config");
+    }
+
+    #[test]
+    fn provider_name() {
+        let provider = TestProvider {
+            config: Arc::new(String::new()),
+        };
+        assert_eq!(provider.provider_name(), "test-tls");
+    }
+
+    #[test]
+    fn provider_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TestProvider>();
+    }
+
+    #[test]
+    fn trait_object_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+        assert_send_sync::<dyn TlsConfigProvider>();
+    }
+}

--- a/src/vector/struct_writer.rs
+++ b/src/vector/struct_writer.rs
@@ -117,6 +117,42 @@ impl StructWriter {
         &mut self.fields[field_idx]
     }
 
+    /// Returns the raw `duckdb_vector` handle for a LIST-typed field.
+    ///
+    /// This is a semantic alias for [`child_vector`][Self::child_vector] that
+    /// makes the intent clear when a struct field has `LIST` type. Use the
+    /// returned handle with [`ListVector`][crate::vector::complex::ListVector]
+    /// methods (`reserve`, `set_entry`, `set_size`, `child_writer`, etc.).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use quack_rs::vector::{StructWriter, VectorWriter, complex::ListVector};
+    /// use libduckdb_sys::duckdb_vector;
+    ///
+    /// // Given a STRUCT output vector where field 2 is LIST<VARCHAR>:
+    /// // let mut sw = unsafe { StructWriter::new(struct_vec, 4) };
+    /// // let list_vec = sw.child_list_vector(2);
+    /// // unsafe { ListVector::reserve(list_vec, 10) };
+    /// // unsafe { ListVector::set_entry(list_vec, 0, 0, 3) };
+    /// // let mut elem_writer = unsafe { ListVector::child_writer(list_vec) };
+    /// // unsafe {
+    /// //     elem_writer.write_varchar(0, "a");
+    /// //     elem_writer.write_varchar(1, "b");
+    /// //     elem_writer.write_varchar(2, "c");
+    /// // }
+    /// // unsafe { ListVector::set_size(list_vec, 3) };
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `field_idx >= field_count`.
+    #[must_use]
+    #[inline]
+    pub fn child_list_vector(&self, field_idx: usize) -> duckdb_vector {
+        self.child_vector(field_idx)
+    }
+
     /// Writes a `bool` value to field `field_idx` at row `row`.
     ///
     /// # Safety

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Structured security warning API for extensions.
+//!
+//! Extensions that access external resources (network, files, credentials) should
+//! emit structured warnings when potentially unsafe operations occur. This module
+//! provides [`ExtensionWarning`], [`WarningSeverity`], and a thread-safe
+//! [`WarningCollector`] that extensions can use to accumulate warnings during
+//! execution and surface them through a consistent interface (e.g., a `DuckDB`
+//! table function like `__extension_warnings()`).
+//!
+//! # Example
+//!
+//! ```rust
+//! use quack_rs::warning::{ExtensionWarning, WarningSeverity, WarningCollector};
+//!
+//! let collector = WarningCollector::new();
+//!
+//! collector.emit(ExtensionWarning {
+//!     code: "TLS_NO_VERIFY",
+//!     severity: WarningSeverity::High,
+//!     message: "TLS certificate verification is disabled".into(),
+//!     cwe: Some(295),
+//! });
+//!
+//! let warnings = collector.drain();
+//! assert_eq!(warnings.len(), 1);
+//! assert_eq!(warnings[0].code, "TLS_NO_VERIFY");
+//! ```
+
+use std::fmt;
+use std::sync::Mutex;
+
+/// Severity level for extension warnings.
+///
+/// Mirrors common security advisory severity levels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WarningSeverity {
+    /// Informational — no security impact, but worth noting.
+    Info,
+    /// Low severity — minimal security impact.
+    Low,
+    /// Medium severity — potential security concern.
+    Medium,
+    /// High severity — significant security risk.
+    High,
+    /// Critical severity — immediate action recommended.
+    Critical,
+}
+
+impl fmt::Display for WarningSeverity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Info => f.write_str("INFO"),
+            Self::Low => f.write_str("LOW"),
+            Self::Medium => f.write_str("MEDIUM"),
+            Self::High => f.write_str("HIGH"),
+            Self::Critical => f.write_str("CRITICAL"),
+        }
+    }
+}
+
+/// A structured warning emitted by an extension.
+///
+/// Warnings carry a machine-readable `code`, a human-readable `message`, a
+/// [`WarningSeverity`] level, and an optional [CWE](https://cwe.mitre.org/)
+/// identifier for security-related warnings.
+#[derive(Debug, Clone)]
+pub struct ExtensionWarning {
+    /// Machine-readable warning code (e.g., `"TLS_NO_VERIFY"`, `"PLAINTEXT_SECRET"`).
+    pub code: &'static str,
+
+    /// Severity level of this warning.
+    pub severity: WarningSeverity,
+
+    /// Human-readable description of the warning.
+    pub message: String,
+
+    /// Optional [CWE](https://cwe.mitre.org/) identifier (e.g., `295` for
+    /// "Improper Certificate Validation").
+    pub cwe: Option<u32>,
+}
+
+impl fmt::Display for ExtensionWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}: {}", self.severity, self.code, self.message)?;
+        if let Some(cwe) = self.cwe {
+            write!(f, " (CWE-{cwe})")?;
+        }
+        Ok(())
+    }
+}
+
+/// A thread-safe collector for [`ExtensionWarning`]s.
+///
+/// Extensions create a single `WarningCollector` (typically stored in their
+/// global or bind-data state) and call [`emit`][Self::emit] whenever a warning
+/// condition is detected. Warnings can later be surfaced through a table
+/// function (e.g., `SELECT * FROM __extension_warnings()`).
+///
+/// # Thread safety
+///
+/// `WarningCollector` uses a [`Mutex`] internally and is safe to share across
+/// threads via `Arc<WarningCollector>`.
+pub struct WarningCollector {
+    warnings: Mutex<Vec<ExtensionWarning>>,
+}
+
+impl WarningCollector {
+    /// Creates a new, empty `WarningCollector`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            warnings: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Emits a warning, adding it to the collector.
+    pub fn emit(&self, warning: ExtensionWarning) {
+        if let Ok(mut warnings) = self.warnings.lock() {
+            warnings.push(warning);
+        }
+    }
+
+    /// Returns the number of warnings currently collected.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.warnings.lock().map(|w| w.len()).unwrap_or(0)
+    }
+
+    /// Returns `true` if no warnings have been collected.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a snapshot of all collected warnings without clearing them.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<ExtensionWarning> {
+        self.warnings.lock().map(|w| w.clone()).unwrap_or_default()
+    }
+
+    /// Drains all collected warnings, returning them and leaving the collector empty.
+    pub fn drain(&self) -> Vec<ExtensionWarning> {
+        self.warnings
+            .lock()
+            .map(|mut w| std::mem::take(&mut *w))
+            .unwrap_or_default()
+    }
+
+    /// Clears all collected warnings.
+    pub fn clear(&self) {
+        if let Ok(mut warnings) = self.warnings.lock() {
+            warnings.clear();
+        }
+    }
+}
+
+impl Default for WarningCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// SAFETY: WarningCollector uses Mutex internally for thread safety.
+// Mutex<Vec<ExtensionWarning>> is Send+Sync when ExtensionWarning is Send,
+// which it is (String + &'static str + Copy types).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_display() {
+        assert_eq!(WarningSeverity::Info.to_string(), "INFO");
+        assert_eq!(WarningSeverity::Low.to_string(), "LOW");
+        assert_eq!(WarningSeverity::Medium.to_string(), "MEDIUM");
+        assert_eq!(WarningSeverity::High.to_string(), "HIGH");
+        assert_eq!(WarningSeverity::Critical.to_string(), "CRITICAL");
+    }
+
+    #[test]
+    fn warning_display_without_cwe() {
+        let w = ExtensionWarning {
+            code: "TEST_WARN",
+            severity: WarningSeverity::Medium,
+            message: "something happened".into(),
+            cwe: None,
+        };
+        assert_eq!(w.to_string(), "[MEDIUM] TEST_WARN: something happened");
+    }
+
+    #[test]
+    fn warning_display_with_cwe() {
+        let w = ExtensionWarning {
+            code: "TLS_NO_VERIFY",
+            severity: WarningSeverity::High,
+            message: "TLS verification disabled".into(),
+            cwe: Some(295),
+        };
+        assert_eq!(
+            w.to_string(),
+            "[HIGH] TLS_NO_VERIFY: TLS verification disabled (CWE-295)"
+        );
+    }
+
+    #[test]
+    fn collector_emit_and_drain() {
+        let c = WarningCollector::new();
+        assert!(c.is_empty());
+        assert_eq!(c.len(), 0);
+
+        c.emit(ExtensionWarning {
+            code: "A",
+            severity: WarningSeverity::Low,
+            message: "first".into(),
+            cwe: None,
+        });
+        c.emit(ExtensionWarning {
+            code: "B",
+            severity: WarningSeverity::High,
+            message: "second".into(),
+            cwe: Some(200),
+        });
+
+        assert_eq!(c.len(), 2);
+        assert!(!c.is_empty());
+
+        let warnings = c.drain();
+        assert_eq!(warnings.len(), 2);
+        assert_eq!(warnings[0].code, "A");
+        assert_eq!(warnings[1].code, "B");
+
+        // After drain, collector should be empty.
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn collector_snapshot_does_not_clear() {
+        let c = WarningCollector::new();
+        c.emit(ExtensionWarning {
+            code: "X",
+            severity: WarningSeverity::Info,
+            message: "test".into(),
+            cwe: None,
+        });
+
+        let snap = c.snapshot();
+        assert_eq!(snap.len(), 1);
+        // Snapshot should not clear.
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn collector_clear() {
+        let c = WarningCollector::new();
+        c.emit(ExtensionWarning {
+            code: "Y",
+            severity: WarningSeverity::Critical,
+            message: "urgent".into(),
+            cwe: Some(798),
+        });
+        assert_eq!(c.len(), 1);
+
+        c.clear();
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn collector_default() {
+        let c = WarningCollector::default();
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn collector_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WarningCollector>();
+    }
+
+    #[test]
+    fn severity_clone_eq_hash() {
+        use std::collections::HashSet;
+
+        let s1 = WarningSeverity::High;
+        let s2 = s1;
+        assert_eq!(s1, s2);
+        let mut set = HashSet::new();
+        set.insert(WarningSeverity::Low);
+        set.insert(WarningSeverity::High);
+        assert_eq!(set.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds three new modules to support secure credential and configuration management in DuckDB extensions:

1. **`secrets` module** — `SecretsManager` trait and `SecretEntry` type for bridging into DuckDB's native `CREATE SECRET` storage. `SecretEntry` implements security hardening: `Debug` redacts field values, `Drop` zeroizes sensitive data with volatile writes, and `PartialEq` is intentionally omitted to prevent non-constant-time comparisons.

2. **`tls` module** — `TlsConfigProvider` trait for type-erased TLS client configuration injection. HTTP-capable extensions supply custom CA bundles, client certificates for mTLS, or restricted cipher suites without coupling `quack-rs` to a specific TLS library. Includes `TlsVersion` enum and `audit_tls_provider()` function that integrates with the `warning` module to flag CWE-295 (cert validation bypass) and CWE-327 (deprecated TLS versions).

3. **`warning` module** — Structured security warning API with `ExtensionWarning`, `WarningSeverity` (Info/Low/Medium/High/Critical), and thread-safe `WarningCollector`. Extensions emit warnings when potentially unsafe operations occur (e.g., disabled TLS verification, plaintext credentials).

Additionally, `ExtensionError` gains `From` impls for `std::io::Error`, `std::ffi::NulError`, and `std::fmt::Error`, allowing the `?` operator to propagate these common error types directly in `register_all()` without `.map_err()`.

## Type of change

- [x] New feature (non-breaking, adds functionality)
- [x] Documentation update

## Checklist

### Code quality
- [x] `cargo test --all-targets` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `cargo doc --no-deps` builds without warnings
- [x] All `unsafe` blocks have `// SAFETY:` comments
- [x] SPDX header on every new file
- [x] All new files under 500 lines

### Testing
- [x] New code has comprehensive unit tests
  - `secrets` module: 10 tests covering builder pattern, cloning, debug redaction, zeroization, and in-memory manager implementation
  - `tls` module: 13 tests covering provider metadata, downcasting, audit function, version ordering, and Send+Sync bounds
  - `warning` module: 10 tests covering severity display, warning formatting, collector operations, and thread safety
- [x] `ExtensionError` tests added for new `From` impls

### Documentation
- [x] Public API documented with rustdoc examples
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `prelude.rs` updated with new exports
- [x] `README.md` updated with feature comparison table
- [x] Book documentation updated (`book/src/concepts/errors.md`, `book/src/reference/changelog.md`)
- [x] Module-level documentation includes security considerations and usage examples

### Safety
- [x] No new panics in FFI callback paths
- [x] `zeroize_string()` uses `write_volatile` with proper `// SAFETY:` comment
- [x] `WarningCollector` uses `Mutex` for thread safety
- [x] All trait objects properly implement `Send + Sync`

## Test Plan

All three new modules include comprehensive unit tests:
- `secrets::tests` validates `SecretEntry` builder, cloning, debug redaction, zeroization, and `SecretsManager` trait implementation
- `tls::tests` validates provider metadata, type-erased downcasting, audit function warnings, and version ordering
- `warning::tests` validates severity display, warning formatting, collector operations (emit, drain, snapshot, clear), and thread safety bounds

The `ExtensionError` tests verify the new `From` impls work correctly with the `?` operator.

All tests pass with `cargo test --all-targets

https://claude.ai/code/session_01QyBMwj2WdFeXasvPNZmc17