### PR TITLE
v0.12.1: Security patch & clippy fixes for Rust 1.95.0

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload criterion reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: criterion-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@
 #
 # Continuous integration — enforces all quality gates.
 #
-# Jobs: check, test (default + bundled + duckdb-1-5), clippy, fmt, doc, msrv,
-#       bench-compile, example-check, scaffold-compile, symbol-check,
-#       extension-load, publish-dry-run, security, nightly.
+# Jobs: check, test (default + bundled + duckdb-1-5), clippy, clippy-beta,
+#       fmt, doc, msrv, bench-compile, example-check, scaffold-compile,
+#       symbol-check, extension-load, publish-dry-run, security, nightly.
 
 name: CI
 
@@ -85,6 +85,22 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --all-targets -- -D warnings
+
+  # Informational early-warning for clippy lints graduating to stable.
+  # `beta` becomes `stable` ~6 weeks later, so a failure here gives a heads-up
+  # before the lint blocks merges. continue-on-error keeps it non-blocking.
+  clippy-beta:
+    name: Clippy (beta, informational)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # beta
+        with:
+          toolchain: beta
+          components: clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo clippy --all-targets --features duckdb-1-5 -- -D warnings
 
   fmt:
     name: Format

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Cache Cargo registry and mdBook binary
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -74,7 +74,7 @@ jobs:
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v5.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: book/book
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-report
           path: |
@@ -256,7 +256,7 @@ jobs:
 
       - name: Upload mutation report
         if: always() && steps.changed.outputs.skip == 'false'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-report-incremental
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
           subject-path: target/package/*.crate
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,33 +11,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **`rustls-webpki` 0.103.10 → 0.103.13** — picks up the fix for two
+Closes nine GitHub Dependabot alerts (two High, seven Low) split across
+the workspace `Cargo.lock` and `examples/hello-ext/Cargo.lock`.
+
+- **`rustls-webpki` 0.103.10 → 0.103.13** — picks up the fix for three
   RustSec advisories reachable via the `bundled` DuckDB build's transitive
   `reqwest` → `rustls` chain:
-    - **[RUSTSEC-2026-0103]** ([GHSA-xgp8-3hg3-c2mh]) — out-of-bounds read
-      in name-constraint enforcement during certificate path building.
-      Reachable only after signature verification, but still warrants a
-      patch bump.
+    - **[RUSTSEC-2026-0098]** ([GHSA-965h-392x-2mh5]) — `nameConstraints`
+      with URI name restrictions were silently ignored instead of enforced.
+      Patched in 0.103.12+; the URI-name path is not on the public Web PKI,
+      so impact is limited to private-PKI consumers.
+    - **[RUSTSEC-2026-0103]** ([GHSA-xgp8-3hg3-c2mh]) — name-constraint
+      enforcement accepted certificates asserting a wildcard subject name.
+      Reachable only after signature verification and requires misissuance.
+      Patched in 0.103.12+.
     - **[RUSTSEC-2026-0104]** — reachable panic when parsing certificate
       revocation lists with a syntactically valid empty `BIT STRING` in
       the `onlySomeReasons` element of an `IssuingDistributionPoint` CRL
-      extension. Affects only applications that use CRLs.
+      extension. Affects only applications that use CRLs. Patched in
+      0.103.13+.
 
   Neither path is exercised by `quack-rs` itself, but the advisories trip
   `cargo deny` for any downstream consumer that has not yet bumped, so
   shipping a release that resolves them is the path of least friction.
 
+- **`rand` 0.9.2 → 0.9.4 / 0.8.5 → 0.8.6** — picks up the fix for
+  **[RUSTSEC-2026-0097]** ([GHSA-cq8v-f236-94qc]) — `ThreadRng` could
+  produce an aliased `&mut BlockRng<ReseedingCore>` (Stacked-Borrows UB)
+  when a custom logger reentered `rand::rng()` from inside a reseed at
+  trace-level logging. Triggering the unsoundness requires a custom
+  global logger that pulls from `rand::rng()` while reseeding, which is
+  not a pattern `quack-rs` uses, but the advisory matches by version
+  range so resolving it removes the alert noise. Patched on every
+  affected line: 0.8.6+, 0.9.3+, 0.10.1+.
+
 ### Changed
 
-- **Dependency bumps (lockfile only)** —
+- **Workspace `Cargo.lock` bumps** —
     - `cc` 1.2.59 → 1.2.61 (build-dep; no API impact)
     - `duckdb` / `libduckdb-sys` 1.10501.0 → 1.10502.0 (latest patch
       release; no API impact for `quack-rs`)
-    - `rand` 0.8.5 → 0.8.6 (transitive via `rust_decimal`)
-- **`examples/hello-ext` lockfile** —
+    - `rand` 0.8.5 → 0.8.6 (transitive via `rust_decimal`; security)
+    - `rand` 0.9.2 → 0.9.4 (transitive via `proptest` dev-dep; security)
+- **`examples/hello-ext` `Cargo.lock` bumps** —
     - `libduckdb-sys` 1.10501.0 → 1.10502.0
-    - `rand` 0.9.2 → 0.9.4 (transitive via `getrandom`)
-    - `rustls-webpki` 0.103.10 → 0.103.13 (matches the workspace fix)
+    - `rand` 0.9.2 → 0.9.4 (security)
+    - `rustls-webpki` 0.103.10 → 0.103.13 (security; matches workspace)
 
 ### CI
 
@@ -69,8 +88,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alongside the above; otherwise would have surfaced the next time
   the lint promotion round-trips through `pedantic` or `nursery`.
 
+[RUSTSEC-2026-0097]: https://rustsec.org/advisories/RUSTSEC-2026-0097
+[RUSTSEC-2026-0098]: https://rustsec.org/advisories/RUSTSEC-2026-0098
 [RUSTSEC-2026-0103]: https://rustsec.org/advisories/RUSTSEC-2026-0103
 [RUSTSEC-2026-0104]: https://rustsec.org/advisories/RUSTSEC-2026-0104
+[GHSA-965h-392x-2mh5]: https://github.com/advisories/GHSA-965h-392x-2mh5
+[GHSA-cq8v-f236-94qc]: https://github.com/advisories/GHSA-cq8v-f236-94qc
 [GHSA-xgp8-3hg3-c2mh]: https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh
 
 ## [0.12.0] - 2026-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-05-01
+
+### Security
+
+- **`rustls-webpki` 0.103.10 → 0.103.13** — picks up the fix for two
+  RustSec advisories reachable via the `bundled` DuckDB build's transitive
+  `reqwest` → `rustls` chain:
+    - **[RUSTSEC-2026-0103]** ([GHSA-xgp8-3hg3-c2mh]) — out-of-bounds read
+      in name-constraint enforcement during certificate path building.
+      Reachable only after signature verification, but still warrants a
+      patch bump.
+    - **[RUSTSEC-2026-0104]** — reachable panic when parsing certificate
+      revocation lists with a syntactically valid empty `BIT STRING` in
+      the `onlySomeReasons` element of an `IssuingDistributionPoint` CRL
+      extension. Affects only applications that use CRLs.
+
+  Neither path is exercised by `quack-rs` itself, but the advisories trip
+  `cargo deny` for any downstream consumer that has not yet bumped, so
+  shipping a release that resolves them is the path of least friction.
+
+### Changed
+
+- **Dependency bumps (lockfile only)** —
+    - `cc` 1.2.59 → 1.2.61 (build-dep; no API impact)
+    - `duckdb` / `libduckdb-sys` 1.10501.0 → 1.10502.0 (latest patch
+      release; no API impact for `quack-rs`)
+    - `rand` 0.8.5 → 0.8.6 (transitive via `rust_decimal`)
+- **`examples/hello-ext` lockfile** —
+    - `libduckdb-sys` 1.10501.0 → 1.10502.0
+    - `rand` 0.9.2 → 0.9.4 (transitive via `getrandom`)
+    - `rustls-webpki` 0.103.10 → 0.103.13 (matches the workspace fix)
+
+### CI
+
+- **GitHub Actions pin updates** —
+    - `actions/cache` `v5.0.4` → `v5.0.5`
+    - `actions/upload-artifact` `v7.0.0` → `v7.0.1`
+    - `actions/upload-pages-artifact` `v4.0.0` → `v5.0.0`
+
+  All updates retain SHA-pinned references for supply-chain integrity.
+
+- **New informational `Clippy (beta)` job** — runs the same
+  `cargo clippy --all-targets --features duckdb-1-5 -- -D warnings`
+  invocation on the `beta` Rust toolchain. Marked `continue-on-error`
+  so a beta-only lint regression does not block the merge queue, but
+  surfaces six weeks before the lint reaches `stable`. Originally added
+  in response to `clippy::map_unwrap_or` graduating to `stable` in
+  Rust 1.95.0 and biting `src/warning.rs` after the toolchain rolled
+  forward.
+
+### Fixed
+
+- **`clippy::map_unwrap_or` on `WarningCollector::len`** —
+  `self.warnings.lock().map(|w| w.len()).unwrap_or(0)` rewritten as
+  `self.warnings.lock().map_or(0, |w| w.len())`. Behaviour-preserving;
+  fixes `Clippy` and `Test duckdb-1-5 feature` jobs under Rust 1.95.0.
+- **`clippy::map_unwrap_or_default` on `WarningCollector::snapshot`**
+  (defensive) — same rewrite for the sibling
+  `map(|w| w.clone()).unwrap_or_default()` call. Caught proactively
+  alongside the above; otherwise would have surfaced the next time
+  the lint promotion round-trips through `pedantic` or `nursery`.
+
+[RUSTSEC-2026-0103]: https://rustsec.org/advisories/RUSTSEC-2026-0103
+[RUSTSEC-2026-0104]: https://rustsec.org/advisories/RUSTSEC-2026-0104
+[GHSA-xgp8-3hg3-c2mh]: https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh
+
 ## [0.12.0] - 2026-04-09
 
 ### Added
@@ -830,7 +896,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI pipeline: check, test, clippy, fmt, doc, MSRV, bench-compile
 - `SECURITY.md` vulnerability disclosure policy
 
-[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/tomtom215/quack-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/tomtom215/quack-rs/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tomtom215/quack-rs/compare/v0.9.0...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1591,7 +1591,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "cc",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -463,10 +463,11 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -567,6 +568,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,12 +619,13 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1185,9 +1209,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "cc",
  "flate2",
@@ -1218,8 +1242,14 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1232,6 +1262,15 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1336,6 +1375,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1578,9 +1640,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1662,6 +1724,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1804,7 +1875,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -1818,6 +1889,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1825,7 +1909,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1855,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1896,6 +1980,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -2099,7 +2189,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2775,7 +2865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quack-rs"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Tom F. <tomf@tomtomtech.net>"]

--- a/README.md
+++ b/README.md
@@ -809,16 +809,18 @@ C API exposes it.
 
 See [`CHANGELOG.md`](./CHANGELOG.md) for the full version history.
 
-**v0.12.1** (2026-05-01) — Security/maintenance patch. Bumps `rustls-webpki`
-0.103.10 → 0.103.13 to clear two RustSec advisories
-([RUSTSEC-2026-0103](https://rustsec.org/advisories/RUSTSEC-2026-0103),
+**v0.12.1** (2026-05-01) — Security/maintenance patch. Closes nine
+GitHub Dependabot alerts (two High, seven Low) across both lockfiles by
+bumping `rustls-webpki` 0.103.10 → 0.103.13 (clears
+[RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098),
+[RUSTSEC-2026-0103](https://rustsec.org/advisories/RUSTSEC-2026-0103),
 [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104))
-reachable via the `bundled` DuckDB build's transitive `reqwest` chain;
-neither path is exercised by `quack-rs` itself but downstream `cargo deny`
-runs would flag them. Bumps `duckdb` / `libduckdb-sys` 1.10501.0 → 1.10502.0,
-`cc` 1.2.59 → 1.2.61, `rand` 0.8.5 → 0.8.6 in the workspace lockfile, and
-`libduckdb-sys`, `rand` 0.9.x, `rustls-webpki` in `examples/hello-ext`.
-GitHub Actions pins refreshed (`actions/cache`, `actions/upload-artifact`,
+and `rand` 0.8.5 → 0.8.6 / 0.9.2 → 0.9.4 (clears
+[RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097)).
+None of those paths are exercised by `quack-rs` itself but downstream
+`cargo deny` runs would flag them. Also bumps `duckdb` / `libduckdb-sys`
+1.10501.0 → 1.10502.0 and `cc` 1.2.59 → 1.2.61. GitHub Actions pins
+refreshed (`actions/cache`, `actions/upload-artifact`,
 `actions/upload-pages-artifact`). Fixes two `clippy::map_unwrap_or` /
 `map_unwrap_or_default` sites in `src/warning.rs` (graduated to stable
 clippy in Rust 1.95.0). Adds an informational `Clippy (beta)` CI job so

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
 ```
 
 > The latest crate published to [crates.io](https://crates.io/crates/quack-rs)
-> is **v0.11.0**. Versions v0.12.0 and v0.13.0 are prepared in this repository
-> but have not yet been published. Until the v0.13.0 release workflow runs,
+> is **v0.11.0**. Version v0.12.1 is prepared in this repository but has not
+> yet been published. Until the v0.12.1 release workflow runs,
 > `cargo add quack-rs` resolves to `0.11.0`.
 
 > **DuckDB compatibility**: `quack-rs` supports DuckDB **1.4.x and 1.5.x**.
@@ -808,6 +808,21 @@ C API exposes it.
 ## Changelog
 
 See [`CHANGELOG.md`](./CHANGELOG.md) for the full version history.
+
+**v0.12.1** (2026-05-01) — Security/maintenance patch. Bumps `rustls-webpki`
+0.103.10 → 0.103.13 to clear two RustSec advisories
+([RUSTSEC-2026-0103](https://rustsec.org/advisories/RUSTSEC-2026-0103),
+[RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104))
+reachable via the `bundled` DuckDB build's transitive `reqwest` chain;
+neither path is exercised by `quack-rs` itself but downstream `cargo deny`
+runs would flag them. Bumps `duckdb` / `libduckdb-sys` 1.10501.0 → 1.10502.0,
+`cc` 1.2.59 → 1.2.61, `rand` 0.8.5 → 0.8.6 in the workspace lockfile, and
+`libduckdb-sys`, `rand` 0.9.x, `rustls-webpki` in `examples/hello-ext`.
+GitHub Actions pins refreshed (`actions/cache`, `actions/upload-artifact`,
+`actions/upload-pages-artifact`). Fixes two `clippy::map_unwrap_or` /
+`map_unwrap_or_default` sites in `src/warning.rs` (graduated to stable
+clippy in Rust 1.95.0). Adds an informational `Clippy (beta)` CI job so
+future lint promotions surface ~6 weeks before they reach `stable`.
 
 **v0.12.0** (2026-04-09) — Added `TypedTableFunctionBuilder<S>`, a closure-based
 layer on top of `TableFunctionBuilder` that replaces hand-rolled

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -14,17 +14,27 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
-- **`rustls-webpki` 0.103.10 → 0.103.13** picks up fixes for two RustSec
-  advisories ([RUSTSEC-2026-0103], [RUSTSEC-2026-0104]) reachable via the
-  `bundled` DuckDB build's transitive `reqwest` → `rustls` chain.
-  Neither path is exercised by `quack-rs` itself, but the advisories trip
-  `cargo deny` for downstream consumers, so the patch bump removes
-  friction.
+Closes nine GitHub Dependabot alerts (two High, seven Low) split across
+the workspace `Cargo.lock` and `examples/hello-ext/Cargo.lock`.
+
+- **`rustls-webpki` 0.103.10 → 0.103.13** picks up fixes for three
+  RustSec advisories reachable via the `bundled` DuckDB build's transitive
+  `reqwest` → `rustls` chain: [RUSTSEC-2026-0098] (URI name constraints
+  silently ignored), [RUSTSEC-2026-0103] (wildcard name constraints
+  accepted), [RUSTSEC-2026-0104] (DoS panic on malformed CRL `BIT STRING`).
+  None of these paths are exercised by `quack-rs` itself, but the
+  advisories trip `cargo deny` for downstream consumers, so the patch
+  bump removes friction.
+- **`rand` 0.9.2 → 0.9.4 / 0.8.5 → 0.8.6** picks up the fix for
+  [RUSTSEC-2026-0097] (`ThreadRng` Stacked-Borrows UB when a custom
+  global logger reentered `rand::rng()` during reseed). Patched on
+  every line: 0.8.6+, 0.9.3+, 0.10.1+.
 
 ### Changed
 
-- Lockfile bumps: `cc` 1.2.59 → 1.2.61 (build-dep), `duckdb` /
-  `libduckdb-sys` 1.10501.0 → 1.10502.0, `rand` 0.8.5 → 0.8.6.
+- Workspace lockfile: `cc` 1.2.59 → 1.2.61 (build-dep), `duckdb` /
+  `libduckdb-sys` 1.10501.0 → 1.10502.0, `rand` 0.8.5 → 0.8.6,
+  `rand` 0.9.2 → 0.9.4.
 - `examples/hello-ext` lockfile: `libduckdb-sys` 1.10501.0 → 1.10502.0,
   `rand` 0.9.2 → 0.9.4, `rustls-webpki` 0.103.10 → 0.103.13.
 
@@ -45,6 +55,8 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `WarningCollector::snapshot`: same defensive rewrite for the sibling
   `map(|w| w.clone()).unwrap_or_default()` call site.
 
+[RUSTSEC-2026-0097]: https://rustsec.org/advisories/RUSTSEC-2026-0097
+[RUSTSEC-2026-0098]: https://rustsec.org/advisories/RUSTSEC-2026-0098
 [RUSTSEC-2026-0103]: https://rustsec.org/advisories/RUSTSEC-2026-0103
 [RUSTSEC-2026-0104]: https://rustsec.org/advisories/RUSTSEC-2026-0104
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,6 +10,44 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-05-01
+
+### Security
+
+- **`rustls-webpki` 0.103.10 → 0.103.13** picks up fixes for two RustSec
+  advisories ([RUSTSEC-2026-0103], [RUSTSEC-2026-0104]) reachable via the
+  `bundled` DuckDB build's transitive `reqwest` → `rustls` chain.
+  Neither path is exercised by `quack-rs` itself, but the advisories trip
+  `cargo deny` for downstream consumers, so the patch bump removes
+  friction.
+
+### Changed
+
+- Lockfile bumps: `cc` 1.2.59 → 1.2.61 (build-dep), `duckdb` /
+  `libduckdb-sys` 1.10501.0 → 1.10502.0, `rand` 0.8.5 → 0.8.6.
+- `examples/hello-ext` lockfile: `libduckdb-sys` 1.10501.0 → 1.10502.0,
+  `rand` 0.9.2 → 0.9.4, `rustls-webpki` 0.103.10 → 0.103.13.
+
+### CI
+
+- GitHub Actions pin updates: `actions/cache` `v5.0.4` → `v5.0.5`,
+  `actions/upload-artifact` `v7.0.0` → `v7.0.1`,
+  `actions/upload-pages-artifact` `v4.0.0` → `v5.0.0` (all SHA-pinned).
+- New informational `Clippy (beta)` job runs the same clippy invocation
+  on the `beta` toolchain (`continue-on-error`), so lint promotions
+  surface ~6 weeks before they reach `stable`.
+
+### Fixed
+
+- `WarningCollector::len`: rewrite `map(|w| w.len()).unwrap_or(0)` as
+  `map_or(0, |w| w.len())` to satisfy `clippy::map_unwrap_or`, which
+  graduated to `stable` clippy in Rust 1.95.0.
+- `WarningCollector::snapshot`: same defensive rewrite for the sibling
+  `map(|w| w.clone()).unwrap_or_default()` call site.
+
+[RUSTSEC-2026-0103]: https://rustsec.org/advisories/RUSTSEC-2026-0103
+[RUSTSEC-2026-0104]: https://rustsec.org/advisories/RUSTSEC-2026-0104
+
 ## [0.12.0] — 2026-04-09
 
 ### Added
@@ -498,7 +536,8 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/tomtom215/quack-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/tomtom215/quack-rs/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tomtom215/quack-rs/compare/v0.9.0...v0.10.0

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "cc",
  "libduckdb-sys",

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -495,9 +495,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.10.0"
+version = "0.12.0"
 dependencies = [
  "cc",
  "libduckdb-sys",
@@ -735,9 +735,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -128,7 +128,7 @@ impl WarningCollector {
     /// Returns the number of warnings currently collected.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.warnings.lock().map(|w| w.len()).unwrap_or(0)
+        self.warnings.lock().map_or(0, |w| w.len())
     }
 
     /// Returns `true` if no warnings have been collected.

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -140,7 +140,9 @@ impl WarningCollector {
     /// Returns a snapshot of all collected warnings without clearing them.
     #[must_use]
     pub fn snapshot(&self) -> Vec<ExtensionWarning> {
-        self.warnings.lock().map(|w| w.clone()).unwrap_or_default()
+        self.warnings
+            .lock()
+            .map_or_else(|_| Vec::new(), |w| w.clone())
     }
 
     /// Drains all collected warnings, returning them and leaving the collector empty.


### PR DESCRIPTION
## Summary

Patch release addressing two RustSec advisories in `rustls-webpki` (reachable via bundled DuckDB's transitive dependency chain) and fixing clippy lint violations that graduated to stable in Rust 1.95.0. Adds an informational `Clippy (beta)` CI job to surface future lint promotions ~6 weeks before they reach stable.

## Type of change

- [x] Bug fix (non-breaking, fixes a specific issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [x] CI / tooling / dependency update
- [x] Refactoring (no behaviour change)

## Changes

### Source code
- **`src/warning.rs`**: Rewrote two `map().unwrap_or()` call chains to use `map_or()` / `map_or_else()` to satisfy `clippy::map_unwrap_or` and `clippy::map_unwrap_or_default`, which graduated to stable clippy in Rust 1.95.0:
  - `WarningCollector::len()`: `map(|w| w.len()).unwrap_or(0)` → `map_or(0, |w| w.len())`
  - `WarningCollector::snapshot()`: `map(|w| w.clone()).unwrap_or_default()` → `map_or_else(|_| Vec::new(), |w| w.clone())`

### CI
- **New `Clippy (beta)` job** in `.github/workflows/ci.yml`: Runs clippy on the beta toolchain with `continue-on-error: true` so lint promotions surface ~6 weeks before they reach stable, without blocking merges.
- **GitHub Actions pin updates** (all SHA-pinned for supply-chain integrity):
  - `actions/cache` v5.0.4 → v5.0.5
  - `actions/upload-artifact` v7.0.0 → v7.0.1
  - `actions/upload-pages-artifact` v4.0.0 → v5.0.0

### Documentation
- **`CHANGELOG.md` & `book/src/reference/changelog.md`**: Added v0.12.1 release notes documenting the security fixes, dependency bumps, CI improvements, and clippy fixes.
- **`README.md`**: Updated version references and added v0.12.1 release summary.

### Metadata
- **`Cargo.toml`**: Bumped version from 0.12.0 to 0.12.1.

## Checklist

### Code quality
- [x] `cargo test --all-targets` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt` applied (no diff)
- [x] `cargo doc --no-deps` builds without warnings
- [x] All `unsafe` blocks have a `// SAFETY:` comment
- [x] SPDX header on every new file
- [x] No file exceeds 500 lines

### Testing
- [x] Changes are behaviour-preserving refactors covered by existing tests
- [x] CI passes with the changes

### Documentation
- [x] `CHANGELOG.md` updated with v0.12.1 release notes
- [x] Book updated with release summary
- [x] README.md updated with version references

### Safety
- [x] No new unsafe code introduced
- [x] No new panics introduced

https://claude.ai/code/session_018eWc6Nxt6wXvhEGoZVHRA7