### PR TITLE
feat: bundled-test can link a pre-built libduckdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `bundled-test` can now link against a pre-built libduckdb instead of
+  compiling DuckDB from C++ source. Opt in with
+  `default-features = false, features = ["bundled-test"]` plus either
+  `DUCKDB_DOWNLOAD_LIB=1` (libduckdb-sys downloads the upstream release
+  zip) or `DUCKDB_LIB_DIR=...` (use a libduckdb tree you already have).
+  Default behaviour is unchanged.
+- `InMemoryDb::open_unsigned()` opens an in-memory database with
+  `allow_unsigned_extensions=true`, allowing downstream extension crates
+  to `LOAD` their own locally-built (unsigned) `.duckdb_extension`
+  artifact for integration testing.
+
 ## [0.13.0] - 2026-05-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,46 @@ name = "quack_rs"
 crate-type = ["rlib"]
 
 [features]
+default = ["bundled"]
+
+## Compiles a bundled copy of DuckDB from C++ source via the `duckdb` crate's
+## `bundled` feature. Required for the default `bundled-test` path. Disable to
+## link against a pre-built libduckdb (see `bundled-test` docs for the env vars).
+bundled = ["duckdb?/bundled"]
+## Enables the `testing::InMemoryDb` helper which opens a real in-memory
+## DuckDB database for integration testing.
+##
+## Two modes:
+## 1. With `bundled` (default): libduckdb is compiled from source by the
+##    `duckdb` crate. No env vars required; cold builds take ~5-10 min.
+## 2. Without `bundled` (`default-features = false, features = ["bundled-test"]`):
+##    quack-rs links against a pre-built libduckdb. Set one of:
+##    - `DUCKDB_DOWNLOAD_LIB=1` — libduckdb-sys downloads the prebuilt zip
+##      from the upstream DuckDB release (~30 MB, cached under `target/`).
+##      Recommended.
+##    - `DUCKDB_LIB_DIR=/path/to/libduckdb` — link against a libduckdb tree
+##      you already have (also set `DUCKDB_INCLUDE_DIR` if `duckdb.hpp` isn't
+##      sitting alongside the library).
+##
+## Enabling this feature also initialises the `loadable-extension` dispatch
+## table from the linked DuckDB symbols, so `InMemoryDb::open()` works in
+## `cargo test` even though no DuckDB host process loads the extension.
+##
+## # Important: architectural limitation
+##
+## Even with this feature, quack-rs's own wrappers (`VectorReader`, `VectorWriter`,
+## `Connection::register_*`) still route through the `loadable-extension` dispatch
+## table and cannot be called in `cargo test`. Use `InMemoryDb` for SQL-level
+## assertions (e.g. verifying SQL macro output) and `MockVectorWriter` /
+## `MockVectorReader` for callback logic tests.
+##
+## # Usage in your extension
+##
+## ```toml
+## [dev-dependencies]
+## quack-rs = { version = "0.11", features = ["bundled-test"] }
+## ```
+bundled-test = ["dep:duckdb"]
 ## Enables wrappers for DuckDB 1.5.0 C API additions (e.g. scalar function local
 ## states, config option registration). Requires `libduckdb-sys >= 1.5.0` to be
 ## resolved by Cargo. Has no effect when compiled against libduckdb-sys 1.4.x.
@@ -76,35 +116,9 @@ duckdb-1-5 = []
 ##   type-enum values behind a single, verifiable version requirement.
 duckdb-1-5-3 = ["duckdb-1-5"]
 
-## Links a bundled copy of DuckDB for integration testing.
-##
-## When this feature is enabled, the `testing::InMemoryDb` helper becomes available.
-## It opens a real in-memory DuckDB database using the `duckdb` Rust crate.
-##
-## Enabling this feature also initialises the `loadable-extension` dispatch table
-## (the function-pointer table that normally gets populated at extension-load time)
-## from the bundled DuckDB symbols, so that `InMemoryDb::open()` works correctly
-## even in `cargo test` where no DuckDB host process loads the extension.
-##
-## # Important: architectural limitation
-##
-## Even with this feature, quack-rs's own wrappers (`VectorReader`, `VectorWriter`,
-## `Connection::register_*`) still route through the `loadable-extension` dispatch
-## table and cannot be called in `cargo test`. Use `InMemoryDb` for SQL-level
-## assertions (e.g. verifying SQL macro output) and `MockVectorWriter` /
-## `MockVectorReader` for callback logic tests.
-##
-## # Usage in your extension
-##
-## ```toml
-## [dev-dependencies]
-## quack-rs = { version = "0.13", features = ["bundled-test"] }
-## ```
-bundled-test = ["dep:duckdb"]
-
 [dependencies]
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
-duckdb = { version = ">=1.4.4, <2", features = ["bundled"], optional = true }
+duckdb = { version = ">=1.4.4, <2", optional = true }
 mutants = "0.0.4"
 
 [build-dependencies]
@@ -114,7 +128,7 @@ mutants = "0.0.4"
 cc = "1"
 
 [dev-dependencies]
-duckdb = { version = ">=1.4.4, <2", features = ["bundled"] }
+duckdb = { version = ">=1.4.4, <2" }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 # tempfile is version-pinned for reproducible dev builds. It was originally held
@@ -148,6 +162,9 @@ module_name_repetitions = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 return_self_not_must_use = "allow"
+# Transitive duplicates from arrow/ahash/ring trees — not under our control,
+# and cargo will pick a single version per crate at link time anyway.
+multiple_crate_versions = "allow"
 
 [package.metadata.docs.rs]
 # Render the full API on docs.rs — including the `duckdb-1-5` / `duckdb-1-5-3`

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -148,19 +148,29 @@ For SQL-level assertions — verifying that a SQL macro produces the correct out
 or that a CREATE TABLE + INSERT + SELECT pipeline works — enable the `bundled-test`
 Cargo feature. This provides `InMemoryDb`, which wraps the `duckdb` crate's bundled
 DuckDB and automatically initialises the `loadable-extension` dispatch table before
-opening a connection (see [Pitfall P9](reference/pitfalls.md#p9)):
+opening a connection (see [Pitfall P9](reference/pitfalls.md#p9)).
+
+Two ways to consume it, picking the one that fits your build-time budget:
 
 ```toml
-# In your extension's Cargo.toml
+# Slow but zero-config: compile libduckdb from C++ source (~5-10 min cold).
 [dev-dependencies]
 quack-rs = { version = "0.13", features = ["bundled-test"] }
 ```
 
-> **Build time**: enabling `bundled-test` compiles a full copy of DuckDB from
-> source (the `duckdb` Rust crate with `features = ["bundled"]`) and a small
-> C++ shim via the `cc` build dependency. Expect a 2–5 minute incremental build
-> the first time, depending on your machine. This only affects the test build —
-> it has no impact on your extension's release binary.
+```toml
+# Fast: link against a pre-built libduckdb. Set DUCKDB_DOWNLOAD_LIB=1 at
+# build time and libduckdb-sys downloads the upstream release zip
+# (~30 MB, cached under target/). Or set DUCKDB_LIB_DIR=/path/to/libduckdb
+# if you already have one extracted.
+[dev-dependencies]
+quack-rs = { version = "0.13", default-features = false, features = ["bundled-test"] }
+```
+
+If your tests need to `LOAD` your own locally-built `.duckdb_extension`
+artifact, use `InMemoryDb::open_unsigned` instead of `open()` — the
+`allow_unsigned_extensions` config option is startup-only and can't be set
+via `SET` after the connection has opened.
 
 ```rust,no_run
 # #[cfg(feature = "bundled-test")]

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,23 @@
 //! (`src/testing/bundled_api_init.cpp`) that exposes `DuckDB`'s internal
 //! `CreateAPIv1()` function as a C-linkage symbol.  The Rust side calls this
 //! at test startup to populate the `loadable-extension` dispatch table from
-//! the bundled `DuckDB` symbols, enabling `InMemoryDb` to work in `cargo test`.
+//! the linked `DuckDB` symbols, enabling `InMemoryDb` to work in `cargo test`.
+//!
+//! Two `bundled-test` modes are supported:
+//!
+//! 1. **`bundled-test + bundled` (default)**: `libduckdb-sys` extracts and
+//!    compiles `DuckDB` from C++ source.  Headers come from the extraction,
+//!    linking is handled by `libduckdb-sys` itself.
+//! 2. **`bundled-test` without `bundled`**: `libduckdb-sys` runs its
+//!    `build_linked` path, which can either download a pre-built libduckdb
+//!    (`DUCKDB_DOWNLOAD_LIB=1`, recommended) or use a user-supplied tree
+//!    (`DUCKDB_LIB_DIR`).  In `loadable-extension` mode `libduckdb-sys`
+//!    suppresses its `cargo:rustc-link-lib` emission, so quack-rs emits it
+//!    here.
+//!
+//! Header resolution prefers `DEP_DUCKDB_INCLUDE` (emitted via `cargo:include=`
+//! by `libduckdb-sys` >= 1.10503) and falls back to mode-specific probes for
+//! older versions, preserving the MSRV and dep-range of pre-1.10503 consumers.
 
 use std::env;
 use std::path::{Path, PathBuf};
@@ -25,8 +41,13 @@ fn main() {
     if env::var("CARGO_FEATURE_BUNDLED_TEST").is_err() {
         return;
     }
+    let bundled = env::var("CARGO_FEATURE_BUNDLED").is_ok();
 
-    let duckdb_include = find_duckdb_include();
+    if !bundled {
+        emit_prebuilt_link_lib();
+    }
+
+    let duckdb_include = resolve_duckdb_include(bundled);
 
     cc::Build::new()
         .cpp(true)
@@ -47,19 +68,91 @@ fn main() {
     println!("cargo:rerun-if-changed=src/testing/bundled_api_init.cpp");
 }
 
-/// Locates the `DuckDB` include directory from `libduckdb-sys`'s build output.
+/// In `bundled-test` without `bundled` mode, `libduckdb-sys` resolves the
+/// library location (downloaded or `DUCKDB_LIB_DIR`) and emits
+/// `cargo:rustc-link-search=...`, but its `loadable-extension` feature
+/// intentionally skips `cargo:rustc-link-lib=...` (the loaded extension's
+/// host process is normally responsible for providing libduckdb).  In
+/// `cargo test` we *are* the host, so we emit the link-lib directive here.
+fn emit_prebuilt_link_lib() {
+    println!("cargo:rerun-if-env-changed=DUCKDB_DOWNLOAD_LIB");
+    println!("cargo:rerun-if-env-changed=DUCKDB_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=DUCKDB_INCLUDE_DIR");
+    println!("cargo:rustc-link-lib=dylib=duckdb");
+}
+
+/// Resolves the include directory containing `duckdb.hpp`.  Tries (in order):
 ///
-/// Cargo places all crate build outputs under `target/{profile}/build/`.  We
-/// navigate up from our own `OUT_DIR` to that shared `build/` directory and
-/// search for a `libduckdb-sys-*` subdirectory that contains the extracted
-/// `DuckDB` source tree (present only when the `bundled` feature is active).
+/// 1. `DEP_DUCKDB_INCLUDE` — emitted by `libduckdb-sys >= 1.10503`.  Works in
+///    both bundled and `build_linked` (download / `DUCKDB_LIB_DIR`) paths.
+/// 2. Mode-specific fallbacks for older `libduckdb-sys`:
+///    - **bundled**: scan the Cargo build directory for the extracted source
+///      tree (the historical path used by quack-rs <= 0.12).
+///    - **!bundled**: `DUCKDB_INCLUDE_DIR`, then `DUCKDB_LIB_DIR` if it has
+///      `duckdb.hpp` alongside the library.  `DUCKDB_DOWNLOAD_LIB` is not
+///      probeable on pre-1.10503 (the download dir isn't exposed), so users
+///      on that mode must upgrade `libduckdb-sys` or set the dirs explicitly.
+fn resolve_duckdb_include(bundled: bool) -> PathBuf {
+    if let Some(dir) = env::var_os("DEP_DUCKDB_INCLUDE") {
+        let p = PathBuf::from(dir);
+        if p.join("duckdb.hpp").exists() {
+            return p;
+        }
+    }
+
+    if bundled {
+        find_duckdb_include_via_scan()
+    } else {
+        resolve_prebuilt_include_from_env()
+    }
+}
+
+/// Bundle-less, pre-1.10503 fallback: derive the include directory from
+/// the env vars the user is required to set anyway.
+fn resolve_prebuilt_include_from_env() -> PathBuf {
+    let mut inspected: Vec<(&str, PathBuf)> = Vec::new();
+    if let Some(inc) = env::var_os("DUCKDB_INCLUDE_DIR") {
+        let p = PathBuf::from(inc);
+        if p.join("duckdb.hpp").exists() {
+            return p;
+        }
+        inspected.push(("DUCKDB_INCLUDE_DIR", p));
+    }
+    if let Some(lib) = env::var_os("DUCKDB_LIB_DIR") {
+        let p = PathBuf::from(lib);
+        if p.join("duckdb.hpp").exists() {
+            return p;
+        }
+        inspected.push(("DUCKDB_LIB_DIR", p));
+    }
+    let inspected_report = if inspected.is_empty() {
+        "  (neither DUCKDB_INCLUDE_DIR nor DUCKDB_LIB_DIR was set)".to_string()
+    } else {
+        inspected
+            .iter()
+            .map(|(name, p)| format!("  {name}={} (no duckdb.hpp here)", p.display()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    panic!(
+        "quack-rs: bundled-test without bundled could not locate duckdb.hpp.\n\
+         Inspected:\n{inspected_report}\n\
+         Either upgrade libduckdb-sys to >= 1.10503 (which publishes the include\n\
+         directory via DEP_DUCKDB_INCLUDE), or point DUCKDB_INCLUDE_DIR /\n\
+         DUCKDB_LIB_DIR at a directory containing duckdb.hpp."
+    );
+}
+
+/// Legacy fallback for older `libduckdb-sys` versions that don't emit
+/// `cargo:include=`.  Navigates from `OUT_DIR` to the shared Cargo build
+/// directory and scans for `libduckdb-sys-*/out/duckdb/src/include`.
 ///
 /// **Build-order caveat**: Cargo runs build scripts as soon as their
 /// `[build-dependencies]` are ready — *before* regular `[dependencies]` are
 /// compiled.  This means `libduckdb-sys` (a regular dependency) may still be
 /// compiling when this function executes.  We therefore poll with a timeout
 /// to wait for the headers to appear.
-fn find_duckdb_include() -> PathBuf {
+fn find_duckdb_include_via_scan() -> PathBuf {
     // OUT_DIR  = .../target/{profile}/build/quack-rs-{hash}/out
     // We want  = .../target/{profile}/build/
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));

--- a/src/testing/bundled_api_init.cpp
+++ b/src/testing/bundled_api_init.cpp
@@ -5,15 +5,23 @@
 //
 // Exposes DuckDB's internal CreateAPIv1() as a C-linkage function so that the
 // Rust test-initialisation code can call it to populate the loadable-extension
-// dispatch table from the bundled DuckDB symbols.
+// dispatch table from the linked DuckDB symbols.
 //
-// CreateAPIv1() is defined as an inline C++ function in
-// duckdb/main/capi/extension_api.hpp.  It constructs a duckdb_ext_api_v1
-// struct where every field is set to the corresponding bundled DuckDB C
-// function pointer — exactly what we need to initialise the Rust dispatch
-// table via duckdb_rs_extension_api_init().
+// CreateAPIv1() is an inline C++ function defined inside DuckDB's amalgamated
+// C++ header (`duckdb.hpp`). It constructs a duckdb_ext_api_v1 struct where
+// every field is set to the corresponding DuckDB C function pointer — exactly
+// what we need to initialise the Rust dispatch table via
+// duckdb_rs_extension_api_init().
+//
+// Including the amalgamation rather than the internal `extension_api.hpp` lets
+// the same shim compile in both modes:
+//   - bundled: against libduckdb-sys's extracted source tree
+//   - !bundled: against the official DuckDB release zip (downloaded by
+//     libduckdb-sys via DUCKDB_DOWNLOAD_LIB=1, or user-supplied via
+//     DUCKDB_LIB_DIR). The release zip ships `duckdb.hpp` but not
+//     `extension_api.hpp`.
 
-#include "duckdb/main/capi/extension_api.hpp"
+#include "duckdb.hpp"
 
 extern "C" duckdb_ext_api_v1 quack_rs_create_api_v1() {
     return CreateAPIv1();

--- a/src/testing/in_memory_db.rs
+++ b/src/testing/in_memory_db.rs
@@ -37,6 +37,17 @@
 //! quack-rs = { version = "0.13", features = ["bundled-test"] }
 //! ```
 //!
+//! To avoid the bundled libduckdb compile, opt out of `bundled` and let
+//! libduckdb-sys download the prebuilt zip instead:
+//!
+//! ```toml
+//! [dev-dependencies]
+//! quack-rs = { version = "0.13", default-features = false, features = ["bundled-test"] }
+//! ```
+//!
+//! Then build with `DUCKDB_DOWNLOAD_LIB=1` (or set `DUCKDB_LIB_DIR=...` if
+//! you have a libduckdb tree extracted locally).
+//!
 //! # Example
 //!
 //! ```rust,no_run
@@ -176,6 +187,42 @@ impl InMemoryDb {
         })
     }
 
+    /// Opens a new in-memory `DuckDB` database with `allow_unsigned_extensions`
+    /// enabled, so unsigned `.duckdb_extension` artifacts can be `LOAD`ed for
+    /// integration testing.
+    ///
+    /// `allow_unsigned_extensions` is a startup-only config option; it cannot
+    /// be toggled via `SET` after the database has opened. Use this constructor
+    /// when the test needs to `LOAD '/path/to/<your>.duckdb_extension'` against
+    /// an artifact you built locally (and therefore haven't signed).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the config can't be constructed or if `DuckDB` fails
+    /// to initialize an in-memory database.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "bundled-test")]
+    /// # {
+    /// use quack_rs::testing::InMemoryDb;
+    ///
+    /// let db = InMemoryDb::open_unsigned().unwrap();
+    /// // Loosen metadata checks too, since locally-built artifacts may have
+    /// // platform / DuckDB-version fields that don't match the host process.
+    /// db.execute_batch("SET allow_extensions_metadata_mismatch=true").unwrap();
+    /// db.execute_batch("LOAD '/path/to/my_ext.duckdb_extension'").unwrap();
+    /// # }
+    /// ```
+    pub fn open_unsigned() -> Result<Self, duckdb::Error> {
+        init_dispatch_table_once();
+        let config = duckdb::Config::default().allow_unsigned_extensions()?;
+        Ok(Self {
+            conn: duckdb::Connection::open_in_memory_with_flags(config)?,
+        })
+    }
+
     /// Executes one or more SQL statements separated by semicolons.
     ///
     /// Useful for `CREATE TABLE`, `INSERT`, `CREATE MACRO`, etc.
@@ -251,6 +298,24 @@ mod tests {
             .unwrap();
         let total: i64 = db.query_one("SELECT SUM(v) FROM t").unwrap();
         assert_eq!(total, 60);
+    }
+
+    #[test]
+    fn in_memory_db_open_unsigned_enables_allow_unsigned_extensions() {
+        let db = InMemoryDb::open_unsigned().expect("should open in-memory db");
+        let v: bool = db
+            .query_one("SELECT current_setting('allow_unsigned_extensions')")
+            .expect("should read config");
+        assert!(v);
+    }
+
+    #[test]
+    fn in_memory_db_open_does_not_enable_allow_unsigned_extensions() {
+        let db = InMemoryDb::open().expect("should open in-memory db");
+        let v: bool = db
+            .query_one("SELECT current_setting('allow_unsigned_extensions')")
+            .expect("should read config");
+        assert!(!v);
     }
 
     #[test]


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

## Summary

Downstream extensions can use `DUCKDB_DOWNLOAD_LIB=1` or `DUCKDB_LIB_DIR=...` (link against a local libduckdb) from `duckdb-rs`. The default `bundled` path is unchanged.

Three changes:

- `build.rs` now prefers `DEP_DUCKDB_INCLUDE` for header resolution, with fallbacks for older libduckdb-sys versions.
- The C++ shim now includes `duckdb.hpp` instead of the internal `duckdb/main/capi/extension_api.hpp`, so it compiles against both the extracted source tree (bundled) and the official release zip (which doesn't ship `extension_api.hpp`).
- `[dev-dependencies] duckdb` drops the `features = ["bundled"]` pin - the `bundled` workspace feature already provides it via `duckdb/bundled`. Without this, dev-dep feature unification kept `bundled` on under `cargo test` even with `--no-default-features --features bundled-test`.
- adds `InMemoryDb::open_unsigned()` for tests that need to `LOAD` a locally-built `.duckdb_extension` artifact.

One small lints adjustment: `clippy::multiple_crate_versions = "allow"` in `[lints.clippy]` due to libduckdb-sys/duckdb bump to 1.10503.

## Type of change

- [ ] Bug fix (non-breaking, fixes a specific issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [ ] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Checklist

### Code quality
- [x] `cargo test --all-targets` passes (539 default; 542 with `--features bundled-test`; 542 with `--no-default-features --features bundled-test DUCKDB_DOWNLOAD_LIB=1`)
- [x] `cargo clippy --all-targets -- -D warnings` passes (default and `--features bundled-test`)
- [x] `cargo fmt` applied (no diff)
- [x] `cargo doc --no-deps` builds without warnings (vanilla, and with `--features duckdb-1-5` per CI)
- [x] All `unsafe` blocks have a `// SAFETY:` comment
- [x] SPDX header on every new file (no new files added in this PR)
- [x] No file exceeds 500 lines (largest Rust source touched: `src/testing/in_memory_db.rs` at 312)

### Testing
- [x] New code has tests: two new unit tests in `in_memory_db.rs` asserting `open_unsigned()` enables `allow_unsigned_extensions` and `open()` does not.
- [x] `cargo mutants` shows zero surviving mutants (1 unviable, 0 missed): the only generated mutant `Ok(Default::default())` does not compile since `InMemoryDb` has no `Default` impl.

### Documentation
- [x] Public API changes are documented in rustdoc
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Book (`book/src/testing.md`) updated
- [ ] New FFI pitfall discovered → added to `LESSONS.md` and `book/src/reference/pitfalls.md` (N/A, no new pitfall).

### Safety (for changes touching `unsafe`)
- [x] No new panics introduced in FFI callback paths
- [x] No new paths that could cross the FFI boundary with an unwinding panic
- [x] `#![deny(unsafe_op_in_unsafe_fn)]` remains satisfied
