### PR TITLE
feat: DuckDB 1.5.x C API wrappers, 1.5.3 bump, MSRV 1.87.0

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,7 +26,7 @@ All of these must pass before merging any PR:
 4. `cargo clippy --all-targets -- -D warnings`
 5. `cargo fmt -- --check`
 6. `cargo doc --no-deps` (with `-D warnings`)
-7. `cargo +1.84.1 check` (MSRV)
+7. `cargo +1.87.0 check` (MSRV)
 8. `cargo bench --no-run` (compile check)
 9. Example extension build + clippy + test
 10. Scaffold output compilation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,13 @@ jobs:
           RUSTDOCFLAGS: "-D warnings"
 
   msrv:
-    name: MSRV (1.84.1)
+    name: MSRV (1.87.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # 1.84.1
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # 1.87.0
+        with:
+          toolchain: "1.87.0"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,9 +147,9 @@ jobs:
             os: ubuntu-latest
             toolchain: stable
             command: cargo doc --no-deps --all-features
-          - name: "MSRV 1.84.1"
+          - name: "MSRV 1.87.0"
             os: ubuntu-latest
-            toolchain: "1.84.1"
+            toolchain: "1.87.0"
             command: cargo check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+New safe wrappers for the `DuckDB` 1.5.0+ C extension API, all gated behind the
+`duckdb-1-5` feature. Note that the DuckDB 1.5.3 release picked up in this cycle
+is a bugfix-only patch over 1.5.2 — the C extension API surface (version
+`v1.2.0`) is byte-for-byte unchanged between them — so these additions expose
+1.5.x capabilities the SDK had not yet wrapped rather than anything new to 1.5.3
+specifically.
+
+- **`error_data` module** — `ErrorData`, an RAII wrapper over
+  `duckdb_error_data` (the structured error type returned by several 1.5 APIs).
+  Carries a `DuckDbErrorType` category and a message, and converts into
+  `ExtensionError`. Adds the free function `check_valid_utf8`, exposing
+  `DuckDB`'s own UTF-8 validator.
+- **`expression` module** — `Expression`, an RAII wrapper over
+  `duckdb_expression`, with `return_type`, `is_foldable`, and `fold`. This
+  closes a real gap: `ScalarBindInfo` already returned a raw, unusable
+  `duckdb_expression` from `get_argument`; the new `ScalarBindInfo::argument`
+  returns a safe `Expression`, so bind callbacks can inspect argument types and
+  pre-fold constant arguments once at bind time.
+- **`file_system` module** — `FileSystem`, `FileHandle`, `FileOpenOptions`, and
+  `FileFlag`: read and write files through `DuckDB`'s virtual file system
+  (honouring `httpfs`, in-memory files, and other registered file systems)
+  instead of reaching for `std::fs`.
+- **`appender` module** — `Appender`: bulk row insertion (create, append a
+  `DataChunk`, flush, close) plus the 1.5 additions `clear` (revert buffered
+  rows), `error_data` (structured errors), and `append_default_to_chunk`.
+- **`selection_vector` module** — `SelectionVector`: allocate and fill
+  zero-copy row-index selection vectors.
+- **`instance_cache` module** — `InstanceCache`: share one underlying database
+  instance across repeated opens of the same path.
+- **`Value`** gains `display_string` (canonical string rendering of any value,
+  via `duckdb_value_to_string`) and `TIME_NS` accessors `Value::time_ns` /
+  `Value::as_time_ns` (pairing with the existing `TypeId::TimeNs`).
+- **`Catalog`** gains `type_name` (the catalog's storage type, e.g. `"duckdb"`
+  or a storage extension's name).
+- All new public types are re-exported from the `prelude` behind the
+  `duckdb-1-5` feature.
+
+### Changed
+
+- **`duckdb` / `libduckdb-sys` 1.10502.0 → 1.10503.1** (DuckDB 1.5.2 → 1.5.3) in
+  both the workspace and `examples/hello-ext` `Cargo.lock`. DuckDB 1.5.3 is a
+  bugfix release ([announcement](https://duckdb.org/2026/05/20/announcing-duckdb-153));
+  since the `>=1.4.4, <2` constraint already permitted it, the bundled fixes are
+  picked up purely by the lock-file update with no source changes required for
+  the bump itself.
+
 ## [0.12.1] - 2026-05-01
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 New safe wrappers for the `DuckDB` 1.5.0+ C extension API, all gated behind the
-`duckdb-1-5` feature. Note that the DuckDB 1.5.3 release picked up in this cycle
-is a bugfix-only patch over 1.5.2 — the C extension API surface (version
-`v1.2.0`) is byte-for-byte unchanged between them — so these additions expose
-1.5.x capabilities the SDK had not yet wrapped rather than anything new to 1.5.3
-specifically.
+`duckdb-1-5` feature. DuckDB 1.5.3's C extension *function-pointer* API (version
+`v1.2.0`) is unchanged from 1.5.2; the one new C addition — the
+`DUCKDB_TYPE_VARIANT` (41) type-enum value — is intentionally **not** surfaced
+yet (see Known Limitations for the version-floor reasoning). So the additions
+below mostly expose 1.5.x capabilities the SDK had not previously wrapped rather
+than anything new to 1.5.3 specifically.
 
 - **`error_data` module** — `ErrorData`, an RAII wrapper over
   `duckdb_error_data` (the structured error type returned by several 1.5 APIs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ than anything new to 1.5.3 specifically.
   folding in Dependabot PR #89, the `patch-updates` group) and
   `examples/hello-ext` (1.2.57 → 1.2.62, re-syncing the example lock's older
   `cc`). Build-dependency; no API impact.
+- **MSRV corrected to 1.87.0.** The crate declared `rust-version = "1.84.1"`,
+  but `libduckdb-sys` (1.5.x line, a non-optional dependency) is
+  `edition = "2024"` / `rust-version = "1.85.1"` — so quack-rs has in fact
+  required Rust ≥ 1.85.1 since before this release (`cargo +1.84.1 check` cannot
+  even parse the manifest). The declared MSRV, the CI `MSRV` job (now explicitly
+  pinned with `toolchain: "1.87.0"` so it genuinely gates instead of silently
+  falling back to the `rust-toolchain.toml` stable channel), the release matrix,
+  and all docs/badges are updated to **1.87.0** — a small headroom margin above
+  the 1.85.1 floor.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ than anything new to 1.5.3 specifically.
   picked up purely by the lock-file update with no source changes required for
   the bump itself.
 
+### Documentation
+
+- **New book section "DuckDB 1.5+ APIs"** — dedicated guide pages for the
+  `error_data`, `expression`, `appender`, `file_system`, `selection_vector`, and
+  `instance_cache` modules, wired into `SUMMARY.md`.
+- Refreshed the reference docs (`docs/architecture.md`, `docs/ffi-reference.md`,
+  the `TypeId` reference, `CONTRIBUTING.md`/book source trees) to cover the new
+  modules, and corrected the now-resolved VARIANT/GEOMETRY entries in
+  `Known Limitations` (these type-enum values now exist in the C API as of
+  DuckDB 1.5.3 / 1.5.x; `TypeId::Variant`/`Geometry` remain a tracked follow-up
+  pending a version-floor decision).
+
 ## [0.12.1] - 2026-05-01
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,10 @@ than anything new to 1.5.3 specifically.
   since the `>=1.4.4, <2` constraint already permitted it, the bundled fixes are
   picked up purely by the lock-file update with no source changes required for
   the bump itself.
-- **`cc` 1.2.61 → 1.2.62** in the workspace `Cargo.lock` (build-dependency; no
-  API impact). Folds in Dependabot PR #89 (the `patch-updates` group).
+- **`cc` → 1.2.62** in both `Cargo.lock` files — workspace (1.2.61 → 1.2.62,
+  folding in Dependabot PR #89, the `patch-updates` group) and
+  `examples/hello-ext` (1.2.57 → 1.2.62, re-syncing the example lock's older
+  `cc`). Build-dependency; no API impact.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ than anything new to 1.5.3 specifically.
   since the `>=1.4.4, <2` constraint already permitted it, the bundled fixes are
   picked up purely by the lock-file update with no source changes required for
   the bump itself.
+- **`cc` 1.2.61 → 1.2.62** in the workspace `Cargo.lock` (build-dependency; no
+  API impact). Folds in Dependabot PR #89 (the `patch-updates` group).
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,15 @@ quack-rs/
 │   │   └── builder.rs             # CastFunctionBuilder, CastFunctionInfo, CastMode
 │   ├── client_context.rs          # ClientContext wrapper (requires `duckdb-1-5`)
 │   ├── config_option.rs           # ConfigOption registration (requires `duckdb-1-5`)
-│   ├── copy_function.rs           # Copy function registration (requires `duckdb-1-5`)
+│   ├── copy_function/
+│   │   ├── mod.rs                 # CopyFunctionBuilder (requires `duckdb-1-5`)
+│   │   └── info.rs                # CopyBindInfo, CopySinkInfo, CopyGlobalInitInfo, CopyFinalizeInfo
+│   ├── appender.rs                # Appender — bulk row insertion (requires `duckdb-1-5`)
+│   ├── error_data.rs              # ErrorData, DuckDbErrorType — structured errors (requires `duckdb-1-5`)
+│   ├── expression.rs              # Expression — bound expr inspection/folding (requires `duckdb-1-5`)
+│   ├── file_system.rs             # FileSystem, FileHandle — DuckDB virtual file system (requires `duckdb-1-5`)
+│   ├── instance_cache.rs          # InstanceCache — shared DB instance cache (requires `duckdb-1-5`)
+│   ├── selection_vector.rs        # SelectionVector — zero-copy row-index vectors (requires `duckdb-1-5`)
 │   ├── replacement_scan/
 │   │   └── mod.rs                 # ReplacementScanBuilder — SELECT * FROM 'file.xyz' patterns
 │   ├── types/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thank you for contributing! Please read this document before opening a PR.
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Rust | ≥ 1.84.1 (MSRV) | Compiler |
+| Rust | ≥ 1.87.0 (MSRV) | Compiler |
 | `rustfmt` | stable | Formatting |
 | `clippy` | stable | Linting |
 | `cargo-deny` | latest | License/advisory checks |
@@ -113,8 +113,8 @@ cargo fmt -- --check
 # 5. Documentation — zero broken links or missing docs
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 
-# 6. MSRV — must compile on Rust 1.84.1 (matches CI; excludes benches which use criterion >=1.86)
-cargo +1.84.1 check
+# 6. MSRV — must compile on Rust 1.87.0 (matches CI; excludes benches which use criterion >=1.86)
+cargo +1.87.0 check
 
 # 7. Live extension test — build hello-ext, package it, load in DuckDB 1.4.4 or 1.5.0
 cargo build --release --manifest-path examples/hello-ext/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
+checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
 dependencies = [
  "arrow",
  "cast",
@@ -1209,9 +1209,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,16 @@ crate-type = ["rlib"]
 ## - Scalar function varargs and volatile flags
 ## - Config option registration (extension-defined settings)
 ## - Copy function support (custom `COPY TO` handlers)
-## - Catalog entry lookup
+## - Catalog entry lookup (incl. `Catalog::type_name`)
 ## - Client context access (file system, config, catalog)
 ## - Table description metadata (column count, names, types)
+## - Structured error data + UTF-8 validation (`ErrorData`, `DuckDbErrorType`, `check_valid_utf8`)
+## - Bound expression inspection / constant folding (`Expression`, `ScalarBindInfo::argument`)
+## - Virtual file system access (`FileSystem`, `FileHandle`, `FileOpenOptions`)
+## - Bulk row appender (`Appender`)
+## - Zero-copy selection vectors (`SelectionVector`)
+## - Database instance cache (`InstanceCache`)
+## - `Value::display_string` and `TIME_NS` accessors (`Value::time_ns` / `as_time_ns`)
 duckdb-1-5 = []
 
 ## Links a bundled copy of DuckDB for integration testing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quack-rs"
 version = "0.12.1"
 edition = "2021"
-rust-version = "1.84.1"
+rust-version = "1.87.0"
 authors = ["Tom F. <tomf@tomtomtech.net>"]
 description = "Production-grade Rust SDK for building DuckDB loadable extensions"
 license = "MIT"
@@ -100,8 +100,10 @@ cc = "1"
 duckdb = { version = ">=1.4.4, <2", features = ["bundled"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
-# Pin tempfile to avoid getrandom >=0.4 (which requires edition2024 / Rust >=1.85).
-# proptest requires only `tempfile ^3`, so 3.14 satisfies it while keeping MSRV 1.84.1.
+# tempfile is version-pinned for reproducible dev builds. It was originally held
+# back to avoid getrandom >=0.4 (edition2024 / Rust >=1.85) when MSRV was 1.84.1;
+# now that MSRV is 1.87.0 that constraint no longer applies, but the pin is kept
+# to avoid unrelated dev-dependency churn. proptest only needs `tempfile ^3`.
 tempfile = "=3.27.0"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -327,10 +327,16 @@ append_metadata target/release/libmy_extension.so \
 | [`scaffold`] | Project generator | `generate_scaffold`, `ScaffoldConfig` |
 | [`testing`] | Mock vectors, aggregate harness, and registrar | `AggregateTestHarness<S>`, `MockVectorWriter`, `MockVectorReader`, `MockRegistrar` |
 | [`prelude`] | Common re-exports | `use quack_rs::prelude::*` |
+| [`appender`]¹ | Bulk row appender | `Appender` |
 | [`catalog`]¹ | Catalog entry lookup | `CatalogEntry`, `Catalog`, `CatalogEntryType` |
 | [`client_context`]¹ | Client context access (catalog, config, connection ID) | `ClientContext` |
 | [`config_option`]¹ | Extension-defined configuration options | `ConfigOptionBuilder`, `ConfigOptionScope` |
 | [`copy_function`]¹ | Custom `COPY TO` handlers | `CopyFunctionBuilder`, `CopyBindInfo`, `CopyGlobalInitInfo`, `CopySinkInfo`, `CopyFinalizeInfo` |
+| [`error_data`]¹ | Structured error data + UTF-8 validation | `ErrorData`, `DuckDbErrorType`, `check_valid_utf8` |
+| [`expression`]¹ | Bound expression inspection / constant folding | `Expression` |
+| [`file_system`]¹ | DuckDB virtual file system access | `FileSystem`, `FileHandle`, `FileOpenOptions`, `FileFlag` |
+| [`instance_cache`]¹ | Shared database instance cache | `InstanceCache` |
+| [`selection_vector`]¹ | Zero-copy row-index selection vectors | `SelectionVector` |
 | [`table_description`]¹ | Table metadata (column count, names, types) | `TableDescription` |
 
 > ¹ Requires the `duckdb-1-5` feature flag (DuckDB 1.5.0+).
@@ -372,10 +378,16 @@ append_metadata target/release/libmy_extension.so \
 [`scaffold`]: https://docs.rs/quack-rs/latest/quack_rs/scaffold/index.html
 [`testing`]: https://docs.rs/quack-rs/latest/quack_rs/testing/index.html
 [`prelude`]: https://docs.rs/quack-rs/latest/quack_rs/prelude/index.html
+[`appender`]: https://docs.rs/quack-rs/latest/quack_rs/appender/index.html
 [`catalog`]: https://docs.rs/quack-rs/latest/quack_rs/catalog/index.html
 [`client_context`]: https://docs.rs/quack-rs/latest/quack_rs/client_context/index.html
 [`config_option`]: https://docs.rs/quack-rs/latest/quack_rs/config_option/index.html
 [`copy_function`]: https://docs.rs/quack-rs/latest/quack_rs/copy_function/index.html
+[`error_data`]: https://docs.rs/quack-rs/latest/quack_rs/error_data/index.html
+[`expression`]: https://docs.rs/quack-rs/latest/quack_rs/expression/index.html
+[`file_system`]: https://docs.rs/quack-rs/latest/quack_rs/file_system/index.html
+[`instance_cache`]: https://docs.rs/quack-rs/latest/quack_rs/instance_cache/index.html
+[`selection_vector`]: https://docs.rs/quack-rs/latest/quack_rs/selection_vector/index.html
 [`table_description`]: https://docs.rs/quack-rs/latest/quack_rs/table_description/index.html
 
 ---

--- a/README.md
+++ b/README.md
@@ -805,12 +805,18 @@ does not exist in the C API.
 If DuckDB exposes the window function API in a future C API version, `quack-rs` will
 add wrappers in the relevant release.
 
-### VARIANT type (Iceberg v3)
+### VARIANT and GEOMETRY types
 
-DuckDB v1.5.1 introduced the `VARIANT` type for Iceberg v3 support. This type is
-**not yet exposed** in the DuckDB C Extension API (`DUCKDB_TYPE_VARIANT` does not
-exist in `libduckdb-sys` 1.10501.0). `quack-rs` will add `TypeId::Variant` when the
-C API exposes it.
+DuckDB v1.5.1 introduced the `VARIANT` type (Iceberg v3 support); it landed in
+the C type enum as `DUCKDB_TYPE_VARIANT` (41) in **DuckDB 1.5.3**. The
+`GEOMETRY` type (`DUCKDB_TYPE_GEOMETRY`, 40) is also present in the C API.
+
+`quack-rs` does **not yet** expose `TypeId::Variant` or `TypeId::Geometry`. The
+reason is version-floor, not capability: the `duckdb-1-5` feature is defined
+against DuckDB **1.5.0**, but these constants only exist in later 1.5.x bindings
+(`VARIANT` requires 1.5.3). Exposing them safely needs either a 1.5.3 floor or a
+finer-grained feature gate — a deliberate versioning decision tracked for a
+follow-up release.
 
 > For the full list of resolved and open limitations, see the
 > [Known Limitations](https://quack-rs.com/reference/known-limitations.html) reference page.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://crates.io/crates/quack-rs"><img src="https://img.shields.io/crates/v/quack-rs.svg" alt="Crates.io"></a>
     <a href="https://quack-rs.com/"><img src="https://img.shields.io/badge/docs-book-blue.svg" alt="Documentation"></a>
     <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <a href="https://blog.rust-lang.org/2025/01/30/Rust-1.84.1.html"><img src="https://img.shields.io/badge/MSRV-1.84.1-blue.svg" alt="MSRV: 1.84.1"></a>
+    <a href="https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/"><img src="https://img.shields.io/badge/MSRV-1.87.0-blue.svg" alt="MSRV: 1.87.0"></a>
   </p>
 </div>
 
@@ -913,7 +913,7 @@ cargo test --all-targets                      # all tests pass
 cargo clippy --all-targets -- -D warnings     # no clippy warnings
 cargo fmt -- --check                          # code is formatted
 cargo doc --no-deps                           # docs compile without warnings
-cargo check                                   # MSRV check (Rust 1.84.1)
+cargo check                                   # MSRV check (Rust 1.87.0)
 ```
 
 ---

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,7 +68,7 @@ CI / test (Windows)     ✅
 CI / clippy             ✅
 CI / fmt                ✅
 CI / doc                ✅
-CI / MSRV (1.84.1)      ✅
+CI / MSRV (1.87.0)      ✅
 CI / security           ✅
 ```
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -39,6 +39,15 @@
 - [NULL Handling & Strings](data/nulls-and-strings.md)
 - [INTERVAL Type](data/intervals.md)
 
+# DuckDB 1.5+ APIs
+
+- [Structured Errors](duckdb-1-5/error-data.md)
+- [Bound Expressions](duckdb-1-5/expression.md)
+- [Bulk Appender](duckdb-1-5/appender.md)
+- [Virtual File System](duckdb-1-5/file-system.md)
+- [Selection Vectors](duckdb-1-5/selection-vector.md)
+- [Instance Cache](duckdb-1-5/instance-cache.md)
+
 # Security
 
 - [TLS Configuration](security/tls.md)

--- a/book/src/concepts/types.md
+++ b/book/src/concepts/types.md
@@ -6,7 +6,9 @@ quack-rs provides `TypeId` and `LogicalType` to bridge Rust types and DuckDB col
 
 ## `TypeId`
 
-`TypeId` is an ergonomic enum covering all DuckDB column types:
+`TypeId` is an ergonomic enum covering DuckDB's column types (the `GEOMETRY` and
+`VARIANT` types added in DuckDB 1.5.x are not yet exposed — see
+[Known Limitations](../reference/known-limitations.md)):
 
 ```rust
 use quack_rs::types::TypeId;

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -180,6 +180,12 @@ quack-rs/
 │   ├── copy_function/
 │   │   ├── mod.rs                 # CopyFunctionBuilder (requires `duckdb-1-5`)
 │   │   └── info.rs                # CopyBindInfo, CopySinkInfo, etc.
+│   ├── appender.rs                # Appender — bulk row insertion (requires `duckdb-1-5`)
+│   ├── error_data.rs              # ErrorData, DuckDbErrorType — structured errors (requires `duckdb-1-5`)
+│   ├── expression.rs              # Expression — bound expr inspection/folding (requires `duckdb-1-5`)
+│   ├── file_system.rs             # FileSystem, FileHandle — DuckDB virtual file system (requires `duckdb-1-5`)
+│   ├── instance_cache.rs          # InstanceCache — shared DB instance cache (requires `duckdb-1-5`)
+│   ├── selection_vector.rs        # SelectionVector — zero-copy row-index vectors (requires `duckdb-1-5`)
 │   ├── replacement_scan/
 │   │   └── mod.rs                 # ReplacementScanBuilder — SELECT * FROM 'file.xyz' patterns
 │   ├── types/

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -9,7 +9,7 @@ bug reports, documentation improvements, new pitfall discoveries, and code.
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Rust | ≥ 1.84.1 (MSRV) | Compiler |
+| Rust | ≥ 1.87.0 (MSRV) | Compiler |
 | `rustfmt` | stable | Formatting |
 | `clippy` | stable | Linting |
 | `cargo-msrv` | latest | MSRV verification |
@@ -53,8 +53,8 @@ cargo fmt -- --check
 # Documentation — zero broken links or missing docs
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 
-# MSRV — must compile on Rust 1.84.1 (excludes benches; matches CI)
-cargo +1.84.1 check
+# MSRV — must compile on Rust 1.87.0 (excludes benches; matches CI)
+cargo +1.87.0 check
 ```
 
 These same checks run in CI on every push and pull request.

--- a/book/src/duckdb-1-5/appender.md
+++ b/book/src/duckdb-1-5/appender.md
@@ -1,0 +1,98 @@
+# Bulk Appender
+
+> **Requires the `duckdb-1-5` feature flag** (DuckDB 1.5.0+).
+
+`Appender` is an RAII wrapper around DuckDB's appender — the fastest way to
+bulk-insert rows into an existing table. It pairs the core appender lifecycle
+(create, append a [`DataChunk`], flush, close) with the DuckDB 1.5 additions:
+structured [`ErrorData`](error-data.md) reporting, reverting buffered rows, and
+appending a column's `DEFAULT` value.
+
+## Appending data chunks
+
+```rust,no_run
+use quack_rs::appender::Appender;
+use quack_rs::data_chunk::DataChunk;
+use libduckdb_sys::duckdb_connection;
+
+# unsafe fn load(con: duckdb_connection, chunks: &[DataChunk]) -> Result<(), quack_rs::error_data::ErrorData> {
+// SAFETY: `con` is a valid, open connection (e.g. from an entry point).
+let appender = unsafe { Appender::new(con, None, c"events") }?;
+
+for chunk in chunks {
+    appender.append_chunk(chunk)?;
+}
+
+// Flush and surface any final error explicitly (see "Drop" below).
+appender.close()?;
+# Ok(())
+# }
+```
+
+Pass a schema (or fully-qualified catalog + schema) when the default schema is
+not what you want:
+
+```rust,no_run
+use quack_rs::appender::Appender;
+use libduckdb_sys::duckdb_connection;
+
+# unsafe fn demo(con: duckdb_connection) -> Result<(), quack_rs::error_data::ErrorData> {
+let a = unsafe { Appender::new(con, Some(c"main"), c"events") }?;
+let b = unsafe { Appender::with_catalog(con, Some(c"mydb"), Some(c"main"), c"events") }?;
+# let _ = (a, b);
+# Ok(())
+# }
+```
+
+## Recovering from a failed flush
+
+If a `flush` fails (for example a constraint violation), the rows buffered since
+the last successful flush can be discarded with `clear`, letting you continue
+without re-appending already-committed rows:
+
+```rust,no_run
+use quack_rs::appender::Appender;
+# use libduckdb_sys::duckdb_connection;
+# unsafe fn demo(appender: &Appender) {
+if let Err(err) = appender.flush() {
+    eprintln!("flush failed: {}", err.message().unwrap_or_default());
+    let _ = appender.clear(); // drop the offending buffered rows
+}
+# }
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `Appender::new(con, schema, table)` (unsafe) | Create for `table` in `schema` (`None` = default) |
+| `Appender::with_catalog(con, catalog, schema, table)` (unsafe) | Create fully qualified |
+| `append_chunk(&chunk)` | Append an entire [`DataChunk`] |
+| `append_default_to_chunk(&chunk, col, row)` | Write a column's `DEFAULT` into a chunk cell |
+| `flush()` | Flush buffered rows without closing |
+| `close()` | Flush and close (no further appends) |
+| `clear()` | Discard buffered, unflushed rows |
+| `error_data()` | Structured [`ErrorData`] from the last failed operation |
+
+Every fallible method returns `Result<(), `[`ErrorData`]`>` (or `Result<Self, ErrorData>`
+for the constructors).
+
+## Safety
+
+`new` and `with_catalog` are `unsafe`: you must pass a valid, open
+`duckdb_connection` (such as the one provided to your extension's entry point).
+
+## Drop
+
+Dropping an `Appender` flushes and destroys it, but the final flush's result is
+**ignored**. To observe an error from the last batch, call `close()` (or a final
+`flush()`) explicitly before the appender goes out of scope.
+
+## Related modules
+
+- [Reading & Writing Vectors](../data/vectors.md) — building the [`DataChunk`]s you append
+- [Structured Errors](error-data.md) — the [`ErrorData`] returned on failure
+- [The Entry Point](../concepts/entry-point.md) — where you obtain a connection
+
+[`DataChunk`]: https://docs.rs/quack-rs/latest/quack_rs/data_chunk/struct.DataChunk.html
+[`ErrorData`]: https://docs.rs/quack-rs/latest/quack_rs/error_data/struct.ErrorData.html

--- a/book/src/duckdb-1-5/error-data.md
+++ b/book/src/duckdb-1-5/error-data.md
@@ -1,0 +1,112 @@
+# Structured Errors
+
+> **Requires the `duckdb-1-5` feature flag** (DuckDB 1.5.0+).
+
+`ErrorData` is an RAII wrapper around DuckDB's `duckdb_error_data` handle — the
+structured error type returned by several DuckDB 1.5 C API surfaces. Unlike a
+bare error string, an `ErrorData` carries both a human-readable **message** and a
+machine-readable **category** ([`DuckDbErrorType`]), so your extension can branch
+on the *kind* of failure (for example, distinguishing `Io` from `OutOfMemory`).
+
+It is the common currency of the other 1.5 modules: [`Expression::fold`](expression.md),
+the [virtual file system](file-system.md), and the [appender](appender.md) all
+report failures as an `ErrorData`.
+
+## Inspecting an error
+
+```rust,no_run
+use quack_rs::error_data::{DuckDbErrorType, ErrorData};
+
+# fn handle(err: ErrorData) {
+if err.has_error() {
+    match err.error_type() {
+        DuckDbErrorType::Io => eprintln!("I/O failure"),
+        DuckDbErrorType::OutOfMemory => eprintln!("out of memory"),
+        other => eprintln!("{other:?}: {}", err.message().unwrap_or_default()),
+    }
+}
+# }
+```
+
+## Constructing an error
+
+Build a structured error to hand back to DuckDB (for example from a callback):
+
+```rust,no_run
+use quack_rs::error_data::{DuckDbErrorType, ErrorData};
+
+let err = ErrorData::new(DuckDbErrorType::InvalidInput, "row index out of range");
+assert!(err.has_error());
+assert_eq!(err.error_type(), DuckDbErrorType::InvalidInput);
+```
+
+## Propagating with `?`
+
+`into_extension_error` converts an `ErrorData` into the SDK's [`ExtensionError`],
+so a structured DuckDB error can flow through the `?` operator in your
+registration or callback logic:
+
+```rust,no_run
+use quack_rs::error::ExtensionError;
+use quack_rs::file_system::{FileOpenOptions, FileSystem};
+use quack_rs::client_context::ClientContext;
+
+# fn read_header(ctx: &ClientContext) -> Result<(), ExtensionError> {
+let fs = FileSystem::from_client_context(ctx)
+    .ok_or_else(|| ExtensionError::new("no file system"))?;
+let handle = fs
+    .open(c"data.bin", &FileOpenOptions::read_only())
+    .map_err(ErrorData::into_extension_error)?;
+# let _ = handle;
+# Ok(())
+# }
+```
+
+## API
+
+| Item | Description |
+|------|-------------|
+| `ErrorData::new(error_type, message)` | Construct a structured error |
+| `ErrorData::from_raw(raw)` (unsafe) | Take ownership of a raw `duckdb_error_data` |
+| `has_error()` | `true` if the handle represents an actual error |
+| `error_type()` | The [`DuckDbErrorType`] category |
+| `message()` | `Option<String>` — the error text |
+| `into_extension_error()` | Consume into an [`ExtensionError`] |
+| `is_null()` / `as_raw()` / `into_raw()` | Handle inspection / escape hatches |
+
+`DuckDbErrorType` is a `#[non_exhaustive]` enum mirroring `duckdb_error_type`
+(`Io`, `OutOfMemory`, `Conversion`, `Catalog`, `Constraint`, `Permission`, …).
+Unknown or future categories map to `DuckDbErrorType::Invalid`.
+
+## UTF-8 validation
+
+The free function `check_valid_utf8` exposes DuckDB's own UTF-8 validator, which
+is stricter than Rust's in some cases. Use it to validate externally-sourced
+bytes before handing them to DuckDB string APIs:
+
+```rust,no_run
+use quack_rs::error_data::check_valid_utf8;
+
+# fn demo(bytes: &[u8]) {
+match check_valid_utf8(bytes) {
+    Ok(()) => { /* safe to pass to DuckDB */ }
+    Err(err) => eprintln!("invalid UTF-8: {}", err.message().unwrap_or_default()),
+}
+# }
+```
+
+## Ownership
+
+`ErrorData` calls `duckdb_destroy_error_data` on drop. When you receive one from
+a fallible 1.5 API, it owns the handle — just let it drop, or call
+`into_extension_error()` / `into_raw()` to move the data out.
+
+## Related modules
+
+- [Bound Expressions](expression.md) — `Expression::fold` returns `ErrorData`
+- [Virtual File System](file-system.md) — file operations return `ErrorData`
+- [Bulk Appender](appender.md) — `Appender::error_data` returns `ErrorData`
+- [Error Handling](../concepts/errors.md) — the SDK's primary [`ExtensionError`] type
+
+[`DuckDbErrorType`]: https://docs.rs/quack-rs/latest/quack_rs/error_data/enum.DuckDbErrorType.html
+[`ExtensionError`]: https://docs.rs/quack-rs/latest/quack_rs/error/struct.ExtensionError.html

--- a/book/src/duckdb-1-5/expression.md
+++ b/book/src/duckdb-1-5/expression.md
@@ -1,0 +1,85 @@
+# Bound Expressions
+
+> **Requires the `duckdb-1-5` feature flag** (DuckDB 1.5.0+).
+
+`Expression` is an RAII wrapper around DuckDB's `duckdb_expression` handle. You
+obtain one from a **scalar function's bind callback** via
+[`ScalarBindInfo::argument`], which lets the bind phase inspect each argument's
+static type and — when the argument is a constant — *fold* it to a concrete
+[`Value`].
+
+This is the canonical way to write scalar functions whose behaviour depends on a
+constant argument (a format string, a precision, a regex) that should be
+validated or pre-computed **once at bind time** rather than on every row.
+
+## Folding a constant argument at bind time
+
+```rust,no_run
+use quack_rs::scalar::ScalarBindInfo;
+use libduckdb_sys::duckdb_bind_info;
+
+unsafe extern "C" fn my_bind(info: duckdb_bind_info) {
+    let bind = unsafe { ScalarBindInfo::new(info) };
+
+    if let Some(arg) = unsafe { bind.argument(0) } {
+        // Inspect the argument's static return type.
+        let _ty = arg.return_type();
+
+        // If the argument is constant, evaluate it once here instead of
+        // recomputing it for every row in the execute callback.
+        if arg.is_foldable() {
+            let ctx = unsafe { bind.get_client_context() };
+            match arg.fold(&ctx) {
+                Ok(value) => {
+                    // Stash `value` as bind data for the execute phase.
+                    let _ = value;
+                }
+                Err(err) => bind.set_error(&err.message().unwrap_or_default()),
+            }
+        }
+    }
+}
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `return_type()` | `Option<`[`LogicalType`]`>` — the expression's static type |
+| `is_foldable()` | `true` if the expression is constant and can be `fold`ed |
+| `fold(&client_context)` | `Result<`[`Value`]`, `[`ErrorData`]`>` — evaluate a constant expression |
+| `from_raw(raw)` (unsafe) / `as_raw()` / `is_null()` | Handle inspection / escape hatches |
+
+`fold` only succeeds when [`is_foldable`][is_foldable] returns `true`; otherwise it
+returns a structured [`ErrorData`].
+
+## Obtaining an `Expression`
+
+`ScalarBindInfo` (the wrapper around a scalar bind callback's `duckdb_bind_info`)
+provides two accessors:
+
+| Method | Returns |
+|--------|---------|
+| `argument(index)` (unsafe) | `Option<Expression>` — RAII, the ergonomic path |
+| `get_argument(index)` (unsafe) | raw `duckdb_expression` — escape hatch |
+
+Use `argument_count()` to bound the index.
+
+## Ownership
+
+`Expression` calls `duckdb_destroy_expression` on drop. The handle returned by
+`argument()` is owned by the caller, so the wrapper cleans it up automatically.
+
+## Related modules
+
+- [Scalar Functions](../functions/scalar.md) — registering the function whose
+  bind callback yields these expressions
+- [Values & Parameter Extraction](../data/values-and-parameters.md) — working
+  with the [`Value`] produced by `fold`
+- [Structured Errors](error-data.md) — the [`ErrorData`] returned on failure
+
+[`ScalarBindInfo::argument`]: https://docs.rs/quack-rs/latest/quack_rs/scalar/struct.ScalarBindInfo.html
+[`Value`]: https://docs.rs/quack-rs/latest/quack_rs/value/struct.Value.html
+[`LogicalType`]: https://docs.rs/quack-rs/latest/quack_rs/types/struct.LogicalType.html
+[`ErrorData`]: https://docs.rs/quack-rs/latest/quack_rs/error_data/struct.ErrorData.html
+[is_foldable]: https://docs.rs/quack-rs/latest/quack_rs/expression/struct.Expression.html#method.is_foldable

--- a/book/src/duckdb-1-5/file-system.md
+++ b/book/src/duckdb-1-5/file-system.md
@@ -1,0 +1,91 @@
+# Virtual File System
+
+> **Requires the `duckdb-1-5` feature flag** (DuckDB 1.5.0+).
+
+This module exposes DuckDB's **virtual file system** (VFS) to your extension, so
+a custom table function, replacement scan, or copy function can read and write
+files through the *same* abstraction DuckDB uses internally. That means
+transparently honouring `httpfs` (`s3://`, `http://`), in-memory files, and any
+other registered file system — instead of reaching for `std::fs` and only ever
+seeing local disk.
+
+## Obtaining a `FileSystem`
+
+A `FileSystem` comes from a [`ClientContext`], which most function callbacks can
+hand you (for example via `BindInfo::get_client_context()` or
+`ScalarBindInfo::get_client_context()`).
+
+## Reading a file
+
+```rust,no_run
+use quack_rs::client_context::ClientContext;
+use quack_rs::file_system::{FileOpenOptions, FileSystem};
+
+# fn read_all(ctx: &ClientContext) -> Option<Vec<u8>> {
+let fs = FileSystem::from_client_context(ctx)?;
+let handle = fs.open(c"s3://bucket/data.csv", &FileOpenOptions::read_only()).ok()?;
+
+let size = handle.size().max(0) as usize;
+let mut buf = vec![0u8; size];
+let n = handle.read(&mut buf).ok()?;
+buf.truncate(n);
+Some(buf)
+# }
+```
+
+## Writing a file
+
+```rust,no_run
+use quack_rs::client_context::ClientContext;
+use quack_rs::file_system::{FileOpenOptions, FileSystem};
+
+# fn write_report(ctx: &ClientContext, bytes: &[u8]) -> Result<(), quack_rs::error_data::ErrorData> {
+let fs = FileSystem::from_client_context(ctx).expect("file system");
+let handle = fs.open(c"report.bin", &FileOpenOptions::write_create())?;
+handle.write(bytes)?;
+handle.sync()?;
+handle.close()?;
+# Ok(())
+# }
+```
+
+## Open options and flags
+
+`FileOpenOptions` describes how a file is opened. Two convenience constructors
+cover the common cases; use `set_flag` for anything else.
+
+| Constructor / method | Effect |
+|----------------------|--------|
+| `FileOpenOptions::read_only()` | Open for reading |
+| `FileOpenOptions::write_create()` | Open for writing, creating if absent |
+| `FileOpenOptions::new()` | Empty; configure with `set_flag` |
+| `set_flag(flag, value)` | Toggle an individual [`FileFlag`]; returns `true` on success |
+
+`FileFlag` variants: `Read`, `Write`, `Create`, `CreateNew`, `Append`.
+
+## `FileHandle` operations
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `read(&mut buf)` | `Result<usize, ErrorData>` | Read up to `buf.len()` bytes (0 = EOF) |
+| `write(&buf)` | `Result<usize, ErrorData>` | Write up to `buf.len()` bytes |
+| `seek(position)` | `Result<(), ErrorData>` | Seek to an absolute byte offset |
+| `tell()` | `i64` | Current byte offset |
+| `size()` | `i64` | Total file size in bytes |
+| `sync()` | `Result<(), ErrorData>` | Flush buffered writes to durable storage |
+| `close()` | `Result<(), ErrorData>` | Close the file |
+| `error_data()` | `ErrorData` | Structured error from the last failed operation |
+
+`FileSystem` exposes `open(path, options)` and `error_data()`. Both `FileSystem`
+and `FileHandle` are RAII: they are destroyed (and the handle closed) on drop.
+
+## Related modules
+
+- [Replacement Scans](../functions/replacement-scan.md) — `SELECT * FROM 'file.xyz'`
+  handlers that read through this file system
+- [Copy Functions](../functions/copy-functions.md) — `COPY TO` handlers that write through it
+- [Structured Errors](error-data.md) — the [`ErrorData`] returned on failure
+
+[`ClientContext`]: https://docs.rs/quack-rs/latest/quack_rs/client_context/struct.ClientContext.html
+[`FileFlag`]: https://docs.rs/quack-rs/latest/quack_rs/file_system/enum.FileFlag.html
+[`ErrorData`]: https://docs.rs/quack-rs/latest/quack_rs/error_data/struct.ErrorData.html

--- a/book/src/duckdb-1-5/instance-cache.md
+++ b/book/src/duckdb-1-5/instance-cache.md
@@ -1,0 +1,69 @@
+# Instance Cache
+
+> **Requires the `duckdb-1-5` feature flag** (DuckDB 1.5.0+).
+
+An `InstanceCache` lets multiple connections share a single underlying DuckDB
+*instance* for a given database path. Opening the same path twice through the
+cache returns handles backed by the **same** instance, which avoids the
+"database is already open in another instance" conflict and saves the cost of
+re-initialising the database.
+
+This is primarily useful for extensions or host integrations that open secondary
+databases on behalf of a query.
+
+## Opening through the cache
+
+```rust,no_run
+use quack_rs::instance_cache::InstanceCache;
+
+# fn demo() -> Result<(), quack_rs::error::ExtensionError> {
+let cache = InstanceCache::new();
+
+// Returns a duckdb_database the caller OWNS and must close with duckdb_close.
+let db = cache.get_or_create(c"analytics.db", None)?;
+# let _ = db;
+# Ok(())
+# }
+```
+
+Pass a [`DbConfig`] to control how a *freshly created* instance is configured; it
+is ignored when an instance already exists for the path:
+
+```rust,no_run
+use quack_rs::instance_cache::InstanceCache;
+use quack_rs::config::DbConfig;
+
+# fn demo() -> Result<(), quack_rs::error::ExtensionError> {
+let cache = InstanceCache::new();
+let config = DbConfig::new()?;
+// configure `config` as needed...
+let db = cache.get_or_create(c"analytics.db", Some(&config))?;
+# let _ = db;
+# Ok(())
+# }
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `InstanceCache::new()` | Create a new, empty cache |
+| `get_or_create(path, config)` | Open `path`, creating the instance if needed |
+| `as_raw()` | The raw `duckdb_instance_cache` handle |
+
+`get_or_create` returns `Result<duckdb_database, `[`ExtensionError`]`>`; on failure
+the error carries DuckDB's message.
+
+## Ownership
+
+`InstanceCache` is RAII and destroys the cache on drop. The `duckdb_database`
+returned by `get_or_create` is, however, **owned by the caller** — you must close
+it with `duckdb_close` when finished. The cache keeps the *underlying* instance
+alive so that subsequent opens of the same path are cheap.
+
+## Related modules
+
+- [`config`](https://docs.rs/quack-rs/latest/quack_rs/config/struct.DbConfig.html) — `DbConfig`, the RAII configuration builder accepted here
+
+[`DbConfig`]: https://docs.rs/quack-rs/latest/quack_rs/config/struct.DbConfig.html
+[`ExtensionError`]: https://docs.rs/quack-rs/latest/quack_rs/error/struct.ExtensionError.html

--- a/book/src/duckdb-1-5/selection-vector.md
+++ b/book/src/duckdb-1-5/selection-vector.md
@@ -1,0 +1,45 @@
+# Selection Vectors
+
+> **Requires the `duckdb-1-5` feature flag** (DuckDB 1.5.0+).
+
+A `SelectionVector` is a list of row indices used to logically reorder or filter
+a data vector **without copying its payload** — the building block behind
+DuckDB's zero-copy filtering. Extensions that implement custom filtering or
+reordering in vectorized callbacks can allocate one, fill in the indices, and
+hand its raw handle to the relevant DuckDB vector operations.
+
+This is an advanced, low-level primitive; most extensions never need it.
+
+## Allocating and filling
+
+```rust,no_run
+use quack_rs::selection_vector::SelectionVector;
+
+// Select source rows 3, 1, 4, 1, 5 (in that order) — note repeats are allowed.
+let mut sel = SelectionVector::new(5);
+sel.as_mut_slice().copy_from_slice(&[3, 1, 4, 1, 5]);
+
+assert_eq!(sel.len(), 5);
+assert_eq!(sel.as_slice(), &[3, 1, 4, 1, 5]);
+```
+
+The indices are 32-bit (`sel_t` / `u32`) and are **uninitialised** after `new` —
+fill them via `as_mut_slice()` before use.
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `SelectionVector::new(size)` | Allocate a vector of `size` indices |
+| `len()` / `is_empty()` | Number of indices |
+| `as_slice()` | `&[u32]` — read the indices |
+| `as_mut_slice()` | `&mut [u32]` — fill the indices |
+| `as_raw()` | The raw `duckdb_selection_vector` handle for DuckDB vector ops |
+
+`SelectionVector` is RAII: it is destroyed on drop.
+
+## Related modules
+
+- [Reading & Writing Vectors](../data/vectors.md) — the data vectors a selection
+  vector reorders or filters
+- [Complex Types](../data/complex-types.md) — STRUCT / LIST / MAP / ARRAY vectors

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -32,8 +32,8 @@ version and the C API protocol version.
 
 ### What is the minimum supported Rust version (MSRV)?
 
-Rust **1.84.1** or later. This is enforced in `Cargo.toml` with
-`rust-version = "1.84.1"`.
+Rust **1.87.0** or later. This is enforced in `Cargo.toml` with
+`rust-version = "1.87.0"`.
 
 ### Is quack-rs production-ready?
 

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -51,7 +51,7 @@ dependency or your own code panics.
 
 ## Minimum Supported Rust Version
 
-quack-rs requires **Rust ≥ 1.84.1**.
+quack-rs requires **Rust ≥ 1.87.0**.
 
 This MSRV is required for:
 - `&raw mut expr` syntax for creating raw pointers without references (sound and stable since 1.84.0)
@@ -67,7 +67,7 @@ rustup default stable
 Verify:
 
 ```bash
-rustc --version   # must be ≥ 1.84.1
+rustc --version   # must be ≥ 1.87.0
 ```
 
 ---

--- a/book/src/getting-started/quick-start.md
+++ b/book/src/getting-started/quick-start.md
@@ -6,7 +6,7 @@ This page gets you from zero to a working DuckDB extension in three steps.
 
 ## Prerequisites
 
-- Rust ≥ 1.84.1 (MSRV) — install via [rustup](https://rustup.rs/)
+- Rust ≥ 1.87.0 (MSRV) — install via [rustup](https://rustup.rs/)
 - DuckDB CLI (for testing the built extension) — [download](https://duckdb.org/docs/installation/)
 
 ---

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -9,7 +9,7 @@
 [![Crates.io](https://img.shields.io/crates/v/quack-rs.svg)](https://crates.io/crates/quack-rs)
 [![Documentation](https://img.shields.io/badge/docs-book-blue.svg)](https://quack-rs.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![MSRV: 1.84.1](https://img.shields.io/badge/MSRV-1.84.1-blue.svg)](https://blog.rust-lang.org/2025/01/30/Rust-1.84.1.html)
+[![MSRV: 1.87.0](https://img.shields.io/badge/MSRV-1.87.0-blue.svg)](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/)
 
 ---
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -62,6 +62,15 @@ than anything new to 1.5.3 specifically.
   folding in Dependabot PR #89, the `patch-updates` group) and
   `examples/hello-ext` (1.2.57 → 1.2.62, re-syncing the example lock's older
   `cc`). Build-dependency; no API impact.
+- **MSRV corrected to 1.87.0.** The crate declared `rust-version = "1.84.1"`,
+  but `libduckdb-sys` (1.5.x line, a non-optional dependency) is
+  `edition = "2024"` / `rust-version = "1.85.1"` — so quack-rs has in fact
+  required Rust ≥ 1.85.1 since before this release (`cargo +1.84.1 check` cannot
+  even parse the manifest). The declared MSRV, the CI `MSRV` job (now explicitly
+  pinned with `toolchain: "1.87.0"` so it genuinely gates instead of silently
+  falling back to the `rust-toolchain.toml` stable channel), the release matrix,
+  and all docs/badges are updated to **1.87.0** — a small headroom margin above
+  the 1.85.1 floor.
 
 ### Documentation
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -59,6 +59,18 @@ than anything new to 1.5.3 specifically.
   picked up purely by the lock-file update with no source changes required for
   the bump itself.
 
+### Documentation
+
+- **New book section "DuckDB 1.5+ APIs"** — dedicated guide pages for the
+  `error_data`, `expression`, `appender`, `file_system`, `selection_vector`, and
+  `instance_cache` modules, wired into `SUMMARY.md`.
+- Refreshed the reference docs (`docs/architecture.md`, `docs/ffi-reference.md`,
+  the `TypeId` reference, `CONTRIBUTING.md`/book source trees) to cover the new
+  modules, and corrected the now-resolved VARIANT/GEOMETRY entries in
+  `Known Limitations` (these type-enum values now exist in the C API as of
+  DuckDB 1.5.3 / 1.5.x; `TypeId::Variant`/`Geometry` remain a tracked follow-up
+  pending a version-floor decision).
+
 ## [0.12.1] — 2026-05-01
 
 ### Security

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -58,8 +58,10 @@ than anything new to 1.5.3 specifically.
   since the `>=1.4.4, <2` constraint already permitted it, the bundled fixes are
   picked up purely by the lock-file update with no source changes required for
   the bump itself.
-- **`cc` 1.2.61 → 1.2.62** in the workspace `Cargo.lock` (build-dependency; no
-  API impact). Folds in Dependabot PR #89 (the `patch-updates` group).
+- **`cc` → 1.2.62** in both `Cargo.lock` files — workspace (1.2.61 → 1.2.62,
+  folding in Dependabot PR #89, the `patch-updates` group) and
+  `examples/hello-ext` (1.2.57 → 1.2.62, re-syncing the example lock's older
+  `cc`). Build-dependency; no API impact.
 
 ### Documentation
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -58,6 +58,8 @@ than anything new to 1.5.3 specifically.
   since the `>=1.4.4, <2` constraint already permitted it, the bundled fixes are
   picked up purely by the lock-file update with no source changes required for
   the bump itself.
+- **`cc` 1.2.61 → 1.2.62** in the workspace `Cargo.lock` (build-dependency; no
+  API impact). Folds in Dependabot PR #89 (the `patch-updates` group).
 
 ### Documentation
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,6 +10,54 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+New safe wrappers for the `DuckDB` 1.5.0+ C extension API, all gated behind the
+`duckdb-1-5` feature. Note that the DuckDB 1.5.3 release picked up in this cycle
+is a bugfix-only patch over 1.5.2 — the C extension API surface (version
+`v1.2.0`) is byte-for-byte unchanged between them — so these additions expose
+1.5.x capabilities the SDK had not yet wrapped rather than anything new to 1.5.3
+specifically.
+
+- **`error_data` module** — `ErrorData`, an RAII wrapper over
+  `duckdb_error_data` (the structured error type returned by several 1.5 APIs).
+  Carries a `DuckDbErrorType` category and a message, and converts into
+  `ExtensionError`. Adds the free function `check_valid_utf8`, exposing
+  `DuckDB`'s own UTF-8 validator.
+- **`expression` module** — `Expression`, an RAII wrapper over
+  `duckdb_expression`, with `return_type`, `is_foldable`, and `fold`. This
+  closes a real gap: `ScalarBindInfo` already returned a raw, unusable
+  `duckdb_expression` from `get_argument`; the new `ScalarBindInfo::argument`
+  returns a safe `Expression`, so bind callbacks can inspect argument types and
+  pre-fold constant arguments once at bind time.
+- **`file_system` module** — `FileSystem`, `FileHandle`, `FileOpenOptions`, and
+  `FileFlag`: read and write files through `DuckDB`'s virtual file system
+  (honouring `httpfs`, in-memory files, and other registered file systems)
+  instead of reaching for `std::fs`.
+- **`appender` module** — `Appender`: bulk row insertion (create, append a
+  `DataChunk`, flush, close) plus the 1.5 additions `clear` (revert buffered
+  rows), `error_data` (structured errors), and `append_default_to_chunk`.
+- **`selection_vector` module** — `SelectionVector`: allocate and fill
+  zero-copy row-index selection vectors.
+- **`instance_cache` module** — `InstanceCache`: share one underlying database
+  instance across repeated opens of the same path.
+- **`Value`** gains `display_string` (canonical string rendering of any value,
+  via `duckdb_value_to_string`) and `TIME_NS` accessors `Value::time_ns` /
+  `Value::as_time_ns` (pairing with the existing `TypeId::TimeNs`).
+- **`Catalog`** gains `type_name` (the catalog's storage type, e.g. `"duckdb"`
+  or a storage extension's name).
+- All new public types are re-exported from the `prelude` behind the
+  `duckdb-1-5` feature.
+
+### Changed
+
+- **`duckdb` / `libduckdb-sys` 1.10502.0 → 1.10503.1** (DuckDB 1.5.2 → 1.5.3) in
+  both the workspace and `examples/hello-ext` `Cargo.lock`. DuckDB 1.5.3 is a
+  bugfix release ([announcement](https://duckdb.org/2026/05/20/announcing-duckdb-153));
+  since the `>=1.4.4, <2` constraint already permitted it, the bundled fixes are
+  picked up purely by the lock-file update with no source changes required for
+  the bump itself.
+
 ## [0.12.1] — 2026-05-01
 
 ### Security

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -13,11 +13,12 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 New safe wrappers for the `DuckDB` 1.5.0+ C extension API, all gated behind the
-`duckdb-1-5` feature. Note that the DuckDB 1.5.3 release picked up in this cycle
-is a bugfix-only patch over 1.5.2 — the C extension API surface (version
-`v1.2.0`) is byte-for-byte unchanged between them — so these additions expose
-1.5.x capabilities the SDK had not yet wrapped rather than anything new to 1.5.3
-specifically.
+`duckdb-1-5` feature. DuckDB 1.5.3's C extension *function-pointer* API (version
+`v1.2.0`) is unchanged from 1.5.2; the one new C addition — the
+`DUCKDB_TYPE_VARIANT` (41) type-enum value — is intentionally **not** surfaced
+yet (see Known Limitations for the version-floor reasoning). So the additions
+below mostly expose 1.5.x capabilities the SDK had not previously wrapped rather
+than anything new to 1.5.3 specifically.
 
 - **`error_data` module** — `ErrorData`, an RAII wrapper over
   `duckdb_error_data` (the structured error type returned by several 1.5 APIs).

--- a/book/src/reference/known-limitations.md
+++ b/book/src/reference/known-limitations.md
@@ -76,9 +76,15 @@ All constructors have `_from_logical` variants for nested complex types.
 Introspection methods (`get_type_id`, `list_child_type`, `struct_child_count`,
 `decimal_width`, etc.) are also available.
 
-## VARIANT type (Iceberg v3)
+## VARIANT and GEOMETRY types (in the C API; `TypeId` pending)
 
-DuckDB v1.5.1 introduced the `VARIANT` type for Iceberg v3 support.
-This type is **not yet exposed** in the DuckDB C Extension API
-(`DUCKDB_TYPE_VARIANT` does not exist in libduckdb-sys 1.10501.0).
-quack-rs will add `TypeId::Variant` when the C API exposes it.
+DuckDB v1.5.1 introduced the `VARIANT` type for Iceberg v3 support. As of
+**DuckDB 1.5.3** it is present in the C type enum as `DUCKDB_TYPE_VARIANT` (41),
+and the `GEOMETRY` type (`DUCKDB_TYPE_GEOMETRY`, 40) is present as well.
+
+quack-rs does **not yet** expose `TypeId::Variant` or `TypeId::Geometry`. This
+is a version-floor matter rather than a missing C API: the `duckdb-1-5` feature
+targets DuckDB **1.5.0**, but these enum values only exist in later 1.5.x
+bindings (`VARIANT` requires 1.5.3). Adding them under the current feature flag
+would break consumers pinned to libduckdb-sys 1.5.0–1.5.2, so it needs either a
+1.5.3 version floor or a finer-grained feature gate. Tracked as a follow-up.

--- a/book/src/reference/type-id.md
+++ b/book/src/reference/type-id.md
@@ -50,6 +50,13 @@ from `libduckdb-sys` and provides safe, named variants.
 | `TypeId::IntegerLiteral` | `INTEGER_LITERAL` | `DUCKDB_TYPE_INTEGER_LITERAL` | unresolved integer literal (`duckdb-1-5`) |
 | `TypeId::StringLiteral` | `STRING_LITERAL` | `DUCKDB_TYPE_STRING_LITERAL` | unresolved string literal (`duckdb-1-5`) |
 
+> **Not yet exposed:** `DUCKDB_TYPE_GEOMETRY` (40) and `DUCKDB_TYPE_VARIANT` (41)
+> exist in the DuckDB 1.5.x C type enum (`VARIANT` was added in DuckDB 1.5.3), but
+> `quack-rs` does not yet provide `TypeId::Geometry` / `TypeId::Variant`. These
+> constants postdate the `duckdb-1-5` feature's 1.5.0 floor, so exposing them
+> requires a version-gating decision (see
+> [Known Limitations](known-limitations.md)).
+
 ---
 
 ## Methods

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,12 @@ quack_rs
 ├── client_context   ClientContext — client context access (requires `duckdb-1-5`)
 ├── config_option    ConfigOptionBuilder — extension-defined configuration options (requires `duckdb-1-5`)
 ├── copy_function    CopyFunctionBuilder, CopyBindInfo, CopySinkInfo — custom COPY TO handlers (requires `duckdb-1-5`)
+├── appender         Appender — bulk row appender (requires `duckdb-1-5`)
+├── error_data       ErrorData, DuckDbErrorType — structured error data + UTF-8 validation (requires `duckdb-1-5`)
+├── expression       Expression — bound expression inspection / constant folding (requires `duckdb-1-5`)
+├── file_system      FileSystem, FileHandle, FileOpenOptions, FileFlag — DuckDB virtual file system (requires `duckdb-1-5`)
+├── instance_cache   InstanceCache — shared database instance cache (requires `duckdb-1-5`)
+├── selection_vector SelectionVector — zero-copy row-index selection vectors (requires `duckdb-1-5`)
 ├── replacement_scan ReplacementScanBuilder — SELECT * FROM 'file.xyz' patterns
 ├── data_chunk       DataChunk — ergonomic wrapper for duckdb_data_chunk
 ├── value            Value — RAII wrapper for duckdb_value with typed extraction
@@ -96,6 +102,12 @@ quack_rs
 | `client_context` | `ClientContext` — access to connection catalog, config options, and connection ID (requires `duckdb-1-5`) | Yes |
 | `config_option` | `ConfigOptionBuilder` — register extension-defined `SET`/`RESET` configuration options (requires `duckdb-1-5`) | Yes |
 | `copy_function` | `CopyFunctionBuilder`, `CopyBindInfo`, `CopySinkInfo`, `CopyGlobalInitInfo`, `CopyFinalizeInfo` — custom `COPY TO` handler registration (requires `duckdb-1-5`) | Yes |
+| `appender` | `Appender` — bulk row insertion: append a `DataChunk`, flush/close/clear, structured errors (requires `duckdb-1-5`) | Yes |
+| `error_data` | `ErrorData`, `DuckDbErrorType`, `check_valid_utf8` — structured error data and UTF-8 validation (requires `duckdb-1-5`) | Yes |
+| `expression` | `Expression` — inspect/constant-fold scalar-function argument expressions at bind time (requires `duckdb-1-5`) | Yes |
+| `file_system` | `FileSystem`, `FileHandle`, `FileOpenOptions`, `FileFlag` — read/write via DuckDB's virtual file system (requires `duckdb-1-5`) | Yes |
+| `instance_cache` | `InstanceCache` — share one database instance across opens of the same path (requires `duckdb-1-5`) | Yes |
+| `selection_vector` | `SelectionVector` — allocate/fill zero-copy row-index vectors (requires `duckdb-1-5`) | Yes |
 | `table_description` | `TableDescription` — query table column count, names, and types at runtime (requires `duckdb-1-5`) | Yes |
 | `replacement_scan` | `ReplacementScanBuilder` — `SELECT * FROM 'file.xyz'` registration | Yes |
 | `vector::reader` | Typed reads with correct alignment and boolean semantics | Yes |
@@ -163,10 +175,13 @@ Extension crate
 ```
 
 The `duckdb-1-5` cargo feature flag gates modules that depend on DuckDB 1.5.0+
-C API symbols: `catalog`, `client_context`, `config_option`, `copy_function`, and
-`table_description`. It also enables `ScalarFunctionBuilder` methods `varargs()`,
-`volatile()`, `bind()`, and `init()`. The feature is defined in the crate's
-`Cargo.toml` and carries no extra dependencies — it only controls `#[cfg]` gates.
+C API symbols: `appender`, `catalog`, `client_context`, `config_option`,
+`copy_function`, `error_data`, `expression`, `file_system`, `instance_cache`,
+`selection_vector`, and `table_description`. It also enables `ScalarFunctionBuilder`
+methods `varargs()`, `volatile()`, `bind()`, and `init()`, the `ScalarBindInfo::argument`
+accessor, and `Value` methods `display_string()`/`time_ns()`/`as_time_ns()`. The
+feature is defined in the crate's `Cargo.toml` and carries no extra dependencies —
+it only controls `#[cfg]` gates.
 
 The `loadable-extension` feature of `libduckdb-sys` changes the linkage model:
 instead of linking against `libduckdb`, the crate emits a shared library that

--- a/docs/duckdb-v1.5.1-evaluation.md
+++ b/docs/duckdb-v1.5.1-evaluation.md
@@ -1,5 +1,16 @@
 # DuckDB v1.5.1 Compatibility Evaluation for quack-rs
 
+> **⚠️ Historical / superseded (as of 2026-05).** This is a point-in-time
+> evaluation written for DuckDB v1.5.1 and quack-rs 0.7.0; it is retained as a
+> decision record. Since then the project has moved to **DuckDB 1.5.3**
+> (`libduckdb-sys` 1.10503.1) and wrapped a large part of the 1.5.x C API
+> (see the [CHANGELOG](../CHANGELOG.md)). Two specifics in this document are now
+> out of date: `DUCKDB_TYPE_VARIANT` **does** now exist in the C type enum (added
+> in DuckDB 1.5.3, value 41), and the `TypeId` gaps it calls out (`Any`,
+> `SqlNull`, `Varint`) have since been filled. The C extension function-pointer
+> API version remains `v1.2.0`. For the current state, see the
+> [Known Limitations](../book/src/reference/known-limitations.md) reference.
+
 **Date:** 2026-03-27
 **DuckDB Release:** v1.5.1 (2026-03-23, commit 7dbb2e6, codename "variegata")
 **quack-rs Version:** 0.7.0 (2026-03-22)

--- a/docs/ffi-reference.md
+++ b/docs/ffi-reference.md
@@ -364,8 +364,8 @@ See [LESSONS.md](../LESSONS.md) for all 16 pitfalls with full analysis.
 
 ## DuckDB 1.5.0 C API Additions (`duckdb-1-5`)
 
-The following C API functions were added in DuckDB 1.5.0 and are wrapped by five
-new modules behind the `duckdb-1-5` feature gate.
+The following C API functions were added in DuckDB 1.5.0 and are wrapped by the
+modules listed below, all behind the `duckdb-1-5` feature gate.
 
 ### Config option registration
 
@@ -404,6 +404,60 @@ Introspect table column metadata.
 
 - `duckdb_table_description_create` / `duckdb_table_description_destroy`
 - `duckdb_table_description_get_column_count`, `duckdb_table_description_get_column_name`, `duckdb_table_description_get_column_type`
+
+### Structured error data (`error_data`)
+
+The structured error type returned by several 1.5 APIs, plus UTF-8 validation.
+
+- `duckdb_create_error_data` / `duckdb_destroy_error_data`
+- `duckdb_error_data_message`, `duckdb_error_data_error_type`, `duckdb_error_data_has_error`
+- `duckdb_valid_utf8_check`
+
+### Bound expressions (`expression`)
+
+Inspect and constant-fold scalar-function argument expressions at bind time.
+
+- `duckdb_scalar_function_bind_get_argument` (via `ScalarBindInfo::argument`)
+- `duckdb_expression_return_type`, `duckdb_expression_is_foldable`, `duckdb_expression_fold`
+- `duckdb_destroy_expression`
+
+### File system (`file_system`)
+
+Read and write files through DuckDB's virtual file system.
+
+- `duckdb_client_context_get_file_system` / `duckdb_destroy_file_system`, `duckdb_file_system_error_data`
+- `duckdb_file_system_open`
+- `duckdb_create_file_open_options`, `duckdb_file_open_options_set_flag`, `duckdb_destroy_file_open_options`
+- `duckdb_file_handle_read`, `duckdb_file_handle_write`, `duckdb_file_handle_seek`, `duckdb_file_handle_tell`, `duckdb_file_handle_sync`, `duckdb_file_handle_size`, `duckdb_file_handle_close`
+- `duckdb_file_handle_error_data`, `duckdb_destroy_file_handle`
+
+### Appender (`appender`)
+
+Bulk row insertion plus the 1.5 appender additions.
+
+- `duckdb_appender_create`, `duckdb_appender_create_ext`, `duckdb_appender_destroy`
+- `duckdb_append_data_chunk`, `duckdb_appender_flush`, `duckdb_appender_close`
+- `duckdb_appender_clear`, `duckdb_appender_error_data`, `duckdb_append_default_to_chunk`
+
+### Selection vectors (`selection_vector`)
+
+Allocate and fill zero-copy row-index selection vectors.
+
+- `duckdb_create_selection_vector` / `duckdb_destroy_selection_vector`
+- `duckdb_selection_vector_get_data_ptr`
+
+### Instance cache (`instance_cache`)
+
+Share a single underlying database instance across opens of the same path.
+
+- `duckdb_create_instance_cache` / `duckdb_destroy_instance_cache`
+- `duckdb_get_or_create_from_cache`
+
+### Value and catalog additions
+
+- `duckdb_value_to_string` — canonical string rendering (`Value::display_string`)
+- `duckdb_create_time_ns` / `duckdb_get_time_ns` — `TIME_NS` value accessors
+- `duckdb_catalog_get_type_name` — catalog storage type name (`Catalog::type_name`)
 
 ### Scalar function additions
 

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -495,9 +495,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
 dependencies = [
  "flate2",
  "pkg-config",

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/examples/hello-ext/Cargo.toml
+++ b/examples/hello-ext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello-ext"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.84.1"
+rust-version = "1.87.0"
 authors = ["Tom F"]
 license = "MIT"
 description = "Example DuckDB community extension built with quack-rs: word_count, first_word, generate_series_ext, VARCHAR→INTEGER cast"

--- a/examples/hello-ext/README.md
+++ b/examples/hello-ext/README.md
@@ -86,7 +86,7 @@ SELECT * FROM 'hello:DuckDB';             -- → 'Hello, DuckDB!'
 
 ## Prerequisites
 
-- Rust 1.84.1 or later (`rustup update stable`)
+- Rust 1.87.0 or later (`rustup update stable`)
 - DuckDB 1.4.x or 1.5.x CLI for live testing ([download][duckdb-releases])
 
 ## Build

--- a/src/appender.rs
+++ b/src/appender.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Bulk data appending (`DuckDB` 1.5.0+).
+//!
+//! [`Appender`] is an RAII wrapper around `DuckDB`'s appender — the fastest way
+//! to bulk-insert rows into an existing table. This wrapper pairs the core
+//! appender lifecycle (create, append a data chunk, flush, close) with the
+//! 1.5.0 additions: structured [`ErrorData`] reporting
+//! ([`error_data`][Appender::error_data]), reverting buffered-but-unflushed rows
+//! ([`clear`][Appender::clear]), and appending a column's `DEFAULT` value into a
+//! chunk ([`append_default_to_chunk`][Appender::append_default_to_chunk]).
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use quack_rs::appender::Appender;
+//! use quack_rs::data_chunk::DataChunk;
+//! use libduckdb_sys::duckdb_connection;
+//!
+//! # unsafe fn demo(con: duckdb_connection, chunk: &DataChunk) -> Result<(), quack_rs::error_data::ErrorData> {
+//! // SAFETY: `con` is a valid, open connection.
+//! let appender = unsafe { Appender::new(con, None, c"my_table") }?;
+//! appender.append_chunk(chunk)?;
+//! appender.flush()?;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::ffi::CStr;
+
+use libduckdb_sys::{
+    duckdb_append_data_chunk, duckdb_append_default_to_chunk, duckdb_appender,
+    duckdb_appender_clear, duckdb_appender_close, duckdb_appender_create,
+    duckdb_appender_create_ext, duckdb_appender_destroy, duckdb_appender_error_data,
+    duckdb_appender_flush, duckdb_connection, duckdb_state, DuckDBSuccess,
+};
+
+use crate::data_chunk::DataChunk;
+use crate::error_data::ErrorData;
+
+/// Converts an optional `&CStr` into a (possibly null) C string pointer.
+#[inline]
+fn opt_ptr(s: Option<&CStr>) -> *const std::os::raw::c_char {
+    s.map_or(std::ptr::null(), CStr::as_ptr)
+}
+
+/// RAII wrapper for a `duckdb_appender`.
+///
+/// The appender is flushed and destroyed automatically on drop. To surface any
+/// error from the final flush, call [`close`][Appender::close] explicitly before
+/// dropping.
+pub struct Appender {
+    appender: duckdb_appender,
+}
+
+impl Appender {
+    /// Creates an appender for `table` in the given `schema` (or the default
+    /// schema when `schema` is `None`).
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the appender cannot be created
+    /// (for example because the table does not exist).
+    ///
+    /// # Safety
+    ///
+    /// `con` must be a valid, open `duckdb_connection`.
+    pub unsafe fn new(
+        con: duckdb_connection,
+        schema: Option<&CStr>,
+        table: &CStr,
+    ) -> Result<Self, ErrorData> {
+        let mut raw: duckdb_appender = std::ptr::null_mut();
+        // SAFETY: con is valid per caller's contract; the string pointers are
+        // valid for the call; raw is a valid out-pointer.
+        let state =
+            unsafe { duckdb_appender_create(con, opt_ptr(schema), table.as_ptr(), &raw mut raw) };
+        let appender = Self { appender: raw };
+        if state == DuckDBSuccess {
+            Ok(appender)
+        } else {
+            Err(appender.error_data())
+        }
+    }
+
+    /// Creates an appender for `table`, fully qualified by optional `catalog` and
+    /// `schema`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the appender cannot be created.
+    ///
+    /// # Safety
+    ///
+    /// `con` must be a valid, open `duckdb_connection`.
+    pub unsafe fn with_catalog(
+        con: duckdb_connection,
+        catalog: Option<&CStr>,
+        schema: Option<&CStr>,
+        table: &CStr,
+    ) -> Result<Self, ErrorData> {
+        let mut raw: duckdb_appender = std::ptr::null_mut();
+        // SAFETY: con is valid per caller's contract; the string pointers are
+        // valid for the call; raw is a valid out-pointer.
+        let state = unsafe {
+            duckdb_appender_create_ext(
+                con,
+                opt_ptr(catalog),
+                opt_ptr(schema),
+                table.as_ptr(),
+                &raw mut raw,
+            )
+        };
+        let appender = Self { appender: raw };
+        if state == DuckDBSuccess {
+            Ok(appender)
+        } else {
+            Err(appender.error_data())
+        }
+    }
+
+    /// Appends an entire [`DataChunk`] to the table.
+    ///
+    /// The chunk's column types must match the table's.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the append fails.
+    pub fn append_chunk(&self, chunk: &DataChunk) -> Result<(), ErrorData> {
+        // SAFETY: self.appender and chunk.as_raw() are valid.
+        let state = unsafe { duckdb_append_data_chunk(self.appender, chunk.as_raw()) };
+        self.check(state)
+    }
+
+    /// Writes the table column `col`'s `DEFAULT` value into row `row` of `chunk`.
+    ///
+    /// This is useful when building a chunk to append: columns without an
+    /// explicit value can be filled with their schema default.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the default cannot be written.
+    pub fn append_default_to_chunk(
+        &self,
+        chunk: &DataChunk,
+        col: u64,
+        row: u64,
+    ) -> Result<(), ErrorData> {
+        // SAFETY: self.appender and chunk.as_raw() are valid.
+        let state =
+            unsafe { duckdb_append_default_to_chunk(self.appender, chunk.as_raw(), col, row) };
+        self.check(state)
+    }
+
+    /// Flushes buffered rows to the table without closing the appender.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the flush fails (e.g. a constraint
+    /// violation). On failure, buffered rows can be discarded with
+    /// [`clear`][Appender::clear].
+    pub fn flush(&self) -> Result<(), ErrorData> {
+        // SAFETY: self.appender is valid.
+        let state = unsafe { duckdb_appender_flush(self.appender) };
+        self.check(state)
+    }
+
+    /// Flushes and closes the appender. No further rows may be appended.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the final flush fails.
+    pub fn close(&self) -> Result<(), ErrorData> {
+        // SAFETY: self.appender is valid.
+        let state = unsafe { duckdb_appender_close(self.appender) };
+        self.check(state)
+    }
+
+    /// Discards all buffered, unflushed rows.
+    ///
+    /// Useful for recovering after a [`flush`][Appender::flush] error without
+    /// re-appending the rows that were already committed.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the appender state is invalid.
+    pub fn clear(&self) -> Result<(), ErrorData> {
+        // SAFETY: self.appender is valid.
+        let state = unsafe { duckdb_appender_clear(self.appender) };
+        self.check(state)
+    }
+
+    /// Returns the structured error from the most recent failed operation.
+    #[must_use]
+    pub fn error_data(&self) -> ErrorData {
+        // SAFETY: self.appender is valid (possibly representing a failed create);
+        // the call returns an owned error data handle.
+        let raw = unsafe { duckdb_appender_error_data(self.appender) };
+        // SAFETY: raw is an owned duckdb_error_data (possibly null).
+        unsafe { ErrorData::from_raw(raw) }
+    }
+
+    /// Returns the raw handle.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_appender {
+        self.appender
+    }
+
+    /// Converts a `duckdb_state` into a `Result`, reading the appender's error
+    /// data on failure.
+    fn check(&self, state: duckdb_state) -> Result<(), ErrorData> {
+        if state == DuckDBSuccess {
+            Ok(())
+        } else {
+            Err(self.error_data())
+        }
+    }
+}
+
+impl Drop for Appender {
+    fn drop(&mut self) {
+        if !self.appender.is_null() {
+            // SAFETY: self.appender is a valid handle that we own. Destroy flushes
+            // and frees it; we intentionally ignore the state here (use `close`
+            // beforehand to observe a final flush error).
+            unsafe { duckdb_appender_destroy(&raw mut self.appender) };
+        }
+    }
+}
+
+#[cfg(all(test, feature = "bundled-test"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_for_missing_table_reports_error() {
+        // Ensure the dispatch table is populated.
+        let _db = crate::testing::InMemoryDb::open().unwrap();
+
+        let mut db: libduckdb_sys::duckdb_database = std::ptr::null_mut();
+        let mut con: duckdb_connection = std::ptr::null_mut();
+        // SAFETY: dispatch table is initialized; null path opens in-memory.
+        unsafe {
+            assert_eq!(
+                libduckdb_sys::duckdb_open(std::ptr::null(), &raw mut db),
+                DuckDBSuccess
+            );
+            assert_eq!(
+                libduckdb_sys::duckdb_connect(db, &raw mut con),
+                DuckDBSuccess
+            );
+        }
+
+        // SAFETY: con is a valid open connection.
+        let result = unsafe { Appender::new(con, None, c"does_not_exist") };
+        assert!(result.is_err(), "expected create to fail for missing table");
+        let err = result.err().unwrap();
+        assert!(err.has_error());
+
+        // SAFETY: valid handles.
+        unsafe {
+            libduckdb_sys::duckdb_disconnect(&raw mut con);
+            libduckdb_sys::duckdb_close(&raw mut db);
+        }
+    }
+}

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -29,7 +29,8 @@ use libduckdb_sys::{
     duckdb_catalog_entry_type_DUCKDB_CATALOG_ENTRY_TYPE_TABLE,
     duckdb_catalog_entry_type_DUCKDB_CATALOG_ENTRY_TYPE_TYPE,
     duckdb_catalog_entry_type_DUCKDB_CATALOG_ENTRY_TYPE_VIEW, duckdb_catalog_get_entry,
-    duckdb_client_context, duckdb_destroy_catalog, duckdb_destroy_catalog_entry,
+    duckdb_catalog_get_type_name, duckdb_client_context, duckdb_destroy_catalog,
+    duckdb_destroy_catalog_entry,
 };
 
 /// Types of entries in the `DuckDB` catalog.
@@ -196,6 +197,22 @@ impl Catalog {
     #[must_use]
     pub const fn as_raw(&self) -> duckdb_catalog {
         self.catalog
+    }
+
+    /// Returns the type name of this catalog (e.g. `"duckdb"`, `"system"`, or a
+    /// storage extension's name like `"sqlite"`).
+    ///
+    /// Returns `None` if the name is not valid UTF-8.
+    #[must_use]
+    pub fn type_name(&self) -> Option<&str> {
+        // SAFETY: self.catalog is valid per constructor contract. The returned
+        // pointer is owned by DuckDB and remains valid while the catalog lives.
+        let ptr = unsafe { duckdb_catalog_get_type_name(self.catalog) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: ptr is a valid null-terminated UTF-8 string owned by DuckDB.
+        unsafe { CStr::from_ptr(ptr) }.to_str().ok()
     }
 
     /// Look up a catalog entry by type, schema, and name.

--- a/src/error_data.rs
+++ b/src/error_data.rs
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Structured error data (`DuckDB` 1.5.0+).
+//!
+//! [`ErrorData`] is an RAII wrapper around `DuckDB`'s `duckdb_error_data` handle —
+//! the structured error type returned by several 1.5.0 C API surfaces, including
+//! expression folding ([`Expression::fold`][crate::expression::Expression::fold]),
+//! the file system API ([`crate::file_system`]), and the appender error accessor
+//! ([`Appender::error_data`][crate::appender::Appender::error_data]).
+//!
+//! Unlike a bare error string, an `ErrorData` carries both a human-readable
+//! message and a machine-readable [`DuckDbErrorType`] category, so an extension
+//! can branch on the kind of failure (e.g. distinguishing `IO` from
+//! `OutOfMemory`).
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use quack_rs::error_data::{DuckDbErrorType, ErrorData};
+//!
+//! // Construct a structured error to hand back to DuckDB.
+//! let err = ErrorData::new(DuckDbErrorType::InvalidInput, "row index out of range");
+//! assert!(err.has_error());
+//! assert_eq!(err.error_type(), DuckDbErrorType::InvalidInput);
+//! ```
+
+use std::ffi::{CStr, CString};
+
+use libduckdb_sys::{
+    duckdb_create_error_data, duckdb_destroy_error_data, duckdb_error_data,
+    duckdb_error_data_error_type, duckdb_error_data_has_error, duckdb_error_data_message,
+    duckdb_error_type, duckdb_error_type_DUCKDB_ERROR_BINDER,
+    duckdb_error_type_DUCKDB_ERROR_CATALOG, duckdb_error_type_DUCKDB_ERROR_CONNECTION,
+    duckdb_error_type_DUCKDB_ERROR_CONSTRAINT, duckdb_error_type_DUCKDB_ERROR_CONVERSION,
+    duckdb_error_type_DUCKDB_ERROR_DECIMAL, duckdb_error_type_DUCKDB_ERROR_DEPENDENCY,
+    duckdb_error_type_DUCKDB_ERROR_DIVIDE_BY_ZERO, duckdb_error_type_DUCKDB_ERROR_EXECUTOR,
+    duckdb_error_type_DUCKDB_ERROR_EXPRESSION, duckdb_error_type_DUCKDB_ERROR_FATAL,
+    duckdb_error_type_DUCKDB_ERROR_HTTP, duckdb_error_type_DUCKDB_ERROR_INDEX,
+    duckdb_error_type_DUCKDB_ERROR_INTERNAL, duckdb_error_type_DUCKDB_ERROR_INTERRUPT,
+    duckdb_error_type_DUCKDB_ERROR_INVALID, duckdb_error_type_DUCKDB_ERROR_INVALID_INPUT,
+    duckdb_error_type_DUCKDB_ERROR_INVALID_TYPE, duckdb_error_type_DUCKDB_ERROR_IO,
+    duckdb_error_type_DUCKDB_ERROR_MISMATCH_TYPE, duckdb_error_type_DUCKDB_ERROR_MISSING_EXTENSION,
+    duckdb_error_type_DUCKDB_ERROR_NETWORK, duckdb_error_type_DUCKDB_ERROR_NOT_IMPLEMENTED,
+    duckdb_error_type_DUCKDB_ERROR_NULL_POINTER, duckdb_error_type_DUCKDB_ERROR_OBJECT_SIZE,
+    duckdb_error_type_DUCKDB_ERROR_OPTIMIZER, duckdb_error_type_DUCKDB_ERROR_OUT_OF_MEMORY,
+    duckdb_error_type_DUCKDB_ERROR_OUT_OF_RANGE,
+    duckdb_error_type_DUCKDB_ERROR_PARAMETER_NOT_ALLOWED,
+    duckdb_error_type_DUCKDB_ERROR_PARAMETER_NOT_RESOLVED, duckdb_error_type_DUCKDB_ERROR_PARSER,
+    duckdb_error_type_DUCKDB_ERROR_PERMISSION, duckdb_error_type_DUCKDB_ERROR_PLANNER,
+    duckdb_error_type_DUCKDB_ERROR_SCHEDULER, duckdb_error_type_DUCKDB_ERROR_SERIALIZATION,
+    duckdb_error_type_DUCKDB_ERROR_SETTINGS, duckdb_error_type_DUCKDB_ERROR_STAT,
+    duckdb_error_type_DUCKDB_ERROR_SYNTAX, duckdb_error_type_DUCKDB_ERROR_TRANSACTION,
+    duckdb_error_type_DUCKDB_ERROR_UNKNOWN_TYPE, duckdb_valid_utf8_check, idx_t,
+};
+
+use crate::error::ExtensionError;
+
+/// The category of a `DuckDB` error, mirroring `duckdb_error_type`.
+///
+/// Unknown or future error categories map to [`DuckDbErrorType::Invalid`] via
+/// [`from_raw`][DuckDbErrorType::from_raw].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DuckDbErrorType {
+    /// No specific category / invalid.
+    Invalid,
+    /// Value out of the representable range.
+    OutOfRange,
+    /// A type conversion failed.
+    Conversion,
+    /// An unknown type was encountered.
+    UnknownType,
+    /// A decimal-specific error.
+    Decimal,
+    /// A type mismatch.
+    MismatchType,
+    /// Division by zero.
+    DivideByZero,
+    /// An object-size error.
+    ObjectSize,
+    /// An invalid type was supplied.
+    InvalidType,
+    /// A (de)serialization error.
+    Serialization,
+    /// A transaction error.
+    Transaction,
+    /// The requested feature is not implemented.
+    NotImplemented,
+    /// An error in an expression.
+    Expression,
+    /// A catalog error (e.g. missing table).
+    Catalog,
+    /// A parser error.
+    Parser,
+    /// A planner error.
+    Planner,
+    /// A scheduler error.
+    Scheduler,
+    /// An executor error.
+    Executor,
+    /// A constraint violation.
+    Constraint,
+    /// An index error.
+    Index,
+    /// A statistics error.
+    Stat,
+    /// A connection error.
+    Connection,
+    /// A syntax error.
+    Syntax,
+    /// A settings error.
+    Settings,
+    /// A binder error.
+    Binder,
+    /// A network error.
+    Network,
+    /// An optimizer error.
+    Optimizer,
+    /// A null-pointer error.
+    NullPointer,
+    /// An I/O error.
+    Io,
+    /// The query was interrupted.
+    Interrupt,
+    /// A fatal error — the database is in an unusable state.
+    Fatal,
+    /// An internal error (a `DuckDB` bug).
+    Internal,
+    /// Invalid input was supplied.
+    InvalidInput,
+    /// Out of memory.
+    OutOfMemory,
+    /// A permission error.
+    Permission,
+    /// A prepared-statement parameter could not be resolved.
+    ParameterNotResolved,
+    /// A prepared-statement parameter is not allowed here.
+    ParameterNotAllowed,
+    /// A dependency error.
+    Dependency,
+    /// An HTTP error.
+    Http,
+    /// A required extension is missing.
+    MissingExtension,
+}
+
+impl DuckDbErrorType {
+    /// Converts to the `DuckDB` C API constant.
+    #[must_use]
+    pub(crate) const fn to_raw(self) -> duckdb_error_type {
+        match self {
+            Self::Invalid => duckdb_error_type_DUCKDB_ERROR_INVALID,
+            Self::OutOfRange => duckdb_error_type_DUCKDB_ERROR_OUT_OF_RANGE,
+            Self::Conversion => duckdb_error_type_DUCKDB_ERROR_CONVERSION,
+            Self::UnknownType => duckdb_error_type_DUCKDB_ERROR_UNKNOWN_TYPE,
+            Self::Decimal => duckdb_error_type_DUCKDB_ERROR_DECIMAL,
+            Self::MismatchType => duckdb_error_type_DUCKDB_ERROR_MISMATCH_TYPE,
+            Self::DivideByZero => duckdb_error_type_DUCKDB_ERROR_DIVIDE_BY_ZERO,
+            Self::ObjectSize => duckdb_error_type_DUCKDB_ERROR_OBJECT_SIZE,
+            Self::InvalidType => duckdb_error_type_DUCKDB_ERROR_INVALID_TYPE,
+            Self::Serialization => duckdb_error_type_DUCKDB_ERROR_SERIALIZATION,
+            Self::Transaction => duckdb_error_type_DUCKDB_ERROR_TRANSACTION,
+            Self::NotImplemented => duckdb_error_type_DUCKDB_ERROR_NOT_IMPLEMENTED,
+            Self::Expression => duckdb_error_type_DUCKDB_ERROR_EXPRESSION,
+            Self::Catalog => duckdb_error_type_DUCKDB_ERROR_CATALOG,
+            Self::Parser => duckdb_error_type_DUCKDB_ERROR_PARSER,
+            Self::Planner => duckdb_error_type_DUCKDB_ERROR_PLANNER,
+            Self::Scheduler => duckdb_error_type_DUCKDB_ERROR_SCHEDULER,
+            Self::Executor => duckdb_error_type_DUCKDB_ERROR_EXECUTOR,
+            Self::Constraint => duckdb_error_type_DUCKDB_ERROR_CONSTRAINT,
+            Self::Index => duckdb_error_type_DUCKDB_ERROR_INDEX,
+            Self::Stat => duckdb_error_type_DUCKDB_ERROR_STAT,
+            Self::Connection => duckdb_error_type_DUCKDB_ERROR_CONNECTION,
+            Self::Syntax => duckdb_error_type_DUCKDB_ERROR_SYNTAX,
+            Self::Settings => duckdb_error_type_DUCKDB_ERROR_SETTINGS,
+            Self::Binder => duckdb_error_type_DUCKDB_ERROR_BINDER,
+            Self::Network => duckdb_error_type_DUCKDB_ERROR_NETWORK,
+            Self::Optimizer => duckdb_error_type_DUCKDB_ERROR_OPTIMIZER,
+            Self::NullPointer => duckdb_error_type_DUCKDB_ERROR_NULL_POINTER,
+            Self::Io => duckdb_error_type_DUCKDB_ERROR_IO,
+            Self::Interrupt => duckdb_error_type_DUCKDB_ERROR_INTERRUPT,
+            Self::Fatal => duckdb_error_type_DUCKDB_ERROR_FATAL,
+            Self::Internal => duckdb_error_type_DUCKDB_ERROR_INTERNAL,
+            Self::InvalidInput => duckdb_error_type_DUCKDB_ERROR_INVALID_INPUT,
+            Self::OutOfMemory => duckdb_error_type_DUCKDB_ERROR_OUT_OF_MEMORY,
+            Self::Permission => duckdb_error_type_DUCKDB_ERROR_PERMISSION,
+            Self::ParameterNotResolved => duckdb_error_type_DUCKDB_ERROR_PARAMETER_NOT_RESOLVED,
+            Self::ParameterNotAllowed => duckdb_error_type_DUCKDB_ERROR_PARAMETER_NOT_ALLOWED,
+            Self::Dependency => duckdb_error_type_DUCKDB_ERROR_DEPENDENCY,
+            Self::Http => duckdb_error_type_DUCKDB_ERROR_HTTP,
+            Self::MissingExtension => duckdb_error_type_DUCKDB_ERROR_MISSING_EXTENSION,
+        }
+    }
+
+    /// Converts from the `DuckDB` C API constant. Unknown values map to
+    /// [`Invalid`][DuckDbErrorType::Invalid].
+    #[must_use]
+    pub(crate) const fn from_raw(raw: duckdb_error_type) -> Self {
+        match raw {
+            x if x == duckdb_error_type_DUCKDB_ERROR_OUT_OF_RANGE => Self::OutOfRange,
+            x if x == duckdb_error_type_DUCKDB_ERROR_CONVERSION => Self::Conversion,
+            x if x == duckdb_error_type_DUCKDB_ERROR_UNKNOWN_TYPE => Self::UnknownType,
+            x if x == duckdb_error_type_DUCKDB_ERROR_DECIMAL => Self::Decimal,
+            x if x == duckdb_error_type_DUCKDB_ERROR_MISMATCH_TYPE => Self::MismatchType,
+            x if x == duckdb_error_type_DUCKDB_ERROR_DIVIDE_BY_ZERO => Self::DivideByZero,
+            x if x == duckdb_error_type_DUCKDB_ERROR_OBJECT_SIZE => Self::ObjectSize,
+            x if x == duckdb_error_type_DUCKDB_ERROR_INVALID_TYPE => Self::InvalidType,
+            x if x == duckdb_error_type_DUCKDB_ERROR_SERIALIZATION => Self::Serialization,
+            x if x == duckdb_error_type_DUCKDB_ERROR_TRANSACTION => Self::Transaction,
+            x if x == duckdb_error_type_DUCKDB_ERROR_NOT_IMPLEMENTED => Self::NotImplemented,
+            x if x == duckdb_error_type_DUCKDB_ERROR_EXPRESSION => Self::Expression,
+            x if x == duckdb_error_type_DUCKDB_ERROR_CATALOG => Self::Catalog,
+            x if x == duckdb_error_type_DUCKDB_ERROR_PARSER => Self::Parser,
+            x if x == duckdb_error_type_DUCKDB_ERROR_PLANNER => Self::Planner,
+            x if x == duckdb_error_type_DUCKDB_ERROR_SCHEDULER => Self::Scheduler,
+            x if x == duckdb_error_type_DUCKDB_ERROR_EXECUTOR => Self::Executor,
+            x if x == duckdb_error_type_DUCKDB_ERROR_CONSTRAINT => Self::Constraint,
+            x if x == duckdb_error_type_DUCKDB_ERROR_INDEX => Self::Index,
+            x if x == duckdb_error_type_DUCKDB_ERROR_STAT => Self::Stat,
+            x if x == duckdb_error_type_DUCKDB_ERROR_CONNECTION => Self::Connection,
+            x if x == duckdb_error_type_DUCKDB_ERROR_SYNTAX => Self::Syntax,
+            x if x == duckdb_error_type_DUCKDB_ERROR_SETTINGS => Self::Settings,
+            x if x == duckdb_error_type_DUCKDB_ERROR_BINDER => Self::Binder,
+            x if x == duckdb_error_type_DUCKDB_ERROR_NETWORK => Self::Network,
+            x if x == duckdb_error_type_DUCKDB_ERROR_OPTIMIZER => Self::Optimizer,
+            x if x == duckdb_error_type_DUCKDB_ERROR_NULL_POINTER => Self::NullPointer,
+            x if x == duckdb_error_type_DUCKDB_ERROR_IO => Self::Io,
+            x if x == duckdb_error_type_DUCKDB_ERROR_INTERRUPT => Self::Interrupt,
+            x if x == duckdb_error_type_DUCKDB_ERROR_FATAL => Self::Fatal,
+            x if x == duckdb_error_type_DUCKDB_ERROR_INTERNAL => Self::Internal,
+            x if x == duckdb_error_type_DUCKDB_ERROR_INVALID_INPUT => Self::InvalidInput,
+            x if x == duckdb_error_type_DUCKDB_ERROR_OUT_OF_MEMORY => Self::OutOfMemory,
+            x if x == duckdb_error_type_DUCKDB_ERROR_PERMISSION => Self::Permission,
+            x if x == duckdb_error_type_DUCKDB_ERROR_PARAMETER_NOT_RESOLVED => {
+                Self::ParameterNotResolved
+            }
+            x if x == duckdb_error_type_DUCKDB_ERROR_PARAMETER_NOT_ALLOWED => {
+                Self::ParameterNotAllowed
+            }
+            x if x == duckdb_error_type_DUCKDB_ERROR_DEPENDENCY => Self::Dependency,
+            x if x == duckdb_error_type_DUCKDB_ERROR_HTTP => Self::Http,
+            x if x == duckdb_error_type_DUCKDB_ERROR_MISSING_EXTENSION => Self::MissingExtension,
+            _ => Self::Invalid,
+        }
+    }
+}
+
+/// RAII wrapper for a `duckdb_error_data` handle.
+///
+/// Automatically destroyed when dropped. Carries a structured error category
+/// ([`DuckDbErrorType`]) and a human-readable message.
+pub struct ErrorData {
+    raw: duckdb_error_data,
+}
+
+impl ErrorData {
+    /// Creates a new structured error with the given category and message.
+    ///
+    /// If `message` contains an interior null byte it is truncated at that point.
+    #[must_use]
+    pub fn new(error_type: DuckDbErrorType, message: &str) -> Self {
+        let c_msg = CString::new(message).unwrap_or_else(|_| {
+            let pos = message
+                .bytes()
+                .position(|b| b == 0)
+                .unwrap_or(message.len());
+            CString::new(&message.as_bytes()[..pos]).unwrap_or_default()
+        });
+        // SAFETY: error_type.to_raw() is a valid duckdb_error_type and c_msg is a
+        // valid null-terminated string for the duration of the call.
+        let raw = unsafe { duckdb_create_error_data(error_type.to_raw(), c_msg.as_ptr()) };
+        Self { raw }
+    }
+
+    /// Wraps a raw `duckdb_error_data` handle, taking ownership.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a `duckdb_error_data` returned by a `DuckDB` API call (it may
+    /// be null). The caller must not destroy the handle after this call.
+    #[inline]
+    #[must_use]
+    pub const unsafe fn from_raw(raw: duckdb_error_data) -> Self {
+        Self { raw }
+    }
+
+    /// Returns the raw handle without consuming the `ErrorData`.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_error_data {
+        self.raw
+    }
+
+    /// Returns `true` if the underlying handle is null.
+    #[inline]
+    #[must_use]
+    pub const fn is_null(&self) -> bool {
+        self.raw.is_null()
+    }
+
+    /// Returns `true` if this handle represents an actual error.
+    #[must_use]
+    pub fn has_error(&self) -> bool {
+        if self.raw.is_null() {
+            return false;
+        }
+        // SAFETY: self.raw is a non-null, valid duckdb_error_data.
+        unsafe { duckdb_error_data_has_error(self.raw) }
+    }
+
+    /// Returns the error category.
+    #[must_use]
+    pub fn error_type(&self) -> DuckDbErrorType {
+        if self.raw.is_null() {
+            return DuckDbErrorType::Invalid;
+        }
+        // SAFETY: self.raw is a non-null, valid duckdb_error_data.
+        let raw = unsafe { duckdb_error_data_error_type(self.raw) };
+        DuckDbErrorType::from_raw(raw)
+    }
+
+    /// Returns the error message, or `None` if the handle is null or the message
+    /// is not valid UTF-8.
+    ///
+    /// The returned string is owned by `DuckDB` and copied into a Rust `String`.
+    #[must_use]
+    pub fn message(&self) -> Option<String> {
+        if self.raw.is_null() {
+            return None;
+        }
+        // SAFETY: self.raw is a non-null, valid duckdb_error_data. The returned
+        // pointer is owned by the error data and remains valid while it lives.
+        let ptr = unsafe { duckdb_error_data_message(self.raw) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: ptr is a valid null-terminated string owned by the error data.
+        unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .ok()
+            .map(String::from)
+    }
+
+    /// Consumes the `ErrorData` and converts it into an [`ExtensionError`].
+    ///
+    /// Useful for propagating a structured `DuckDB` error through `?`.
+    #[must_use]
+    pub fn into_extension_error(self) -> ExtensionError {
+        let msg = self
+            .message()
+            .unwrap_or_else(|| "unknown DuckDB error".to_owned());
+        ExtensionError::new(msg)
+    }
+
+    /// Consumes the `ErrorData` and returns the raw handle.
+    ///
+    /// The caller takes ownership and must call `duckdb_destroy_error_data`.
+    #[inline]
+    #[must_use]
+    pub const fn into_raw(self) -> duckdb_error_data {
+        let raw = self.raw;
+        std::mem::forget(self);
+        raw
+    }
+}
+
+impl Drop for ErrorData {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            // SAFETY: self.raw is a valid duckdb_error_data that we own.
+            unsafe { duckdb_destroy_error_data(&raw mut self.raw) };
+        }
+    }
+}
+
+/// Checks whether `bytes` form a valid UTF-8 string according to `DuckDB`'s
+/// validator (`DuckDB` 1.5.0+).
+///
+/// `DuckDB` enforces stricter rules than Rust in some cases (e.g. rejecting
+/// certain code points), so this is useful when validating externally-sourced
+/// bytes before handing them to `DuckDB` string APIs.
+///
+/// # Errors
+///
+/// Returns the structured [`ErrorData`] describing the first validation failure.
+pub fn check_valid_utf8(bytes: &[u8]) -> Result<(), ErrorData> {
+    let len = idx_t::try_from(bytes.len()).unwrap_or(idx_t::MAX);
+    // SAFETY: bytes.as_ptr() is valid for `len` bytes; DuckDB only reads them.
+    let raw = unsafe { duckdb_valid_utf8_check(bytes.as_ptr().cast(), len) };
+    // SAFETY: duckdb_valid_utf8_check returns an owned duckdb_error_data handle.
+    let err = unsafe { ErrorData::from_raw(raw) };
+    if err.has_error() {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_VARIANTS: [DuckDbErrorType; 40] = [
+        DuckDbErrorType::Invalid,
+        DuckDbErrorType::OutOfRange,
+        DuckDbErrorType::Conversion,
+        DuckDbErrorType::UnknownType,
+        DuckDbErrorType::Decimal,
+        DuckDbErrorType::MismatchType,
+        DuckDbErrorType::DivideByZero,
+        DuckDbErrorType::ObjectSize,
+        DuckDbErrorType::InvalidType,
+        DuckDbErrorType::Serialization,
+        DuckDbErrorType::Transaction,
+        DuckDbErrorType::NotImplemented,
+        DuckDbErrorType::Expression,
+        DuckDbErrorType::Catalog,
+        DuckDbErrorType::Parser,
+        DuckDbErrorType::Planner,
+        DuckDbErrorType::Scheduler,
+        DuckDbErrorType::Executor,
+        DuckDbErrorType::Constraint,
+        DuckDbErrorType::Index,
+        DuckDbErrorType::Stat,
+        DuckDbErrorType::Connection,
+        DuckDbErrorType::Syntax,
+        DuckDbErrorType::Settings,
+        DuckDbErrorType::Binder,
+        DuckDbErrorType::Network,
+        DuckDbErrorType::Optimizer,
+        DuckDbErrorType::NullPointer,
+        DuckDbErrorType::Io,
+        DuckDbErrorType::Interrupt,
+        DuckDbErrorType::Fatal,
+        DuckDbErrorType::Internal,
+        DuckDbErrorType::InvalidInput,
+        DuckDbErrorType::OutOfMemory,
+        DuckDbErrorType::Permission,
+        DuckDbErrorType::ParameterNotResolved,
+        DuckDbErrorType::ParameterNotAllowed,
+        DuckDbErrorType::Dependency,
+        DuckDbErrorType::Http,
+        DuckDbErrorType::MissingExtension,
+    ];
+
+    #[test]
+    fn error_type_round_trip_all_variants() {
+        for variant in ALL_VARIANTS {
+            let raw = variant.to_raw();
+            assert_eq!(
+                DuckDbErrorType::from_raw(raw),
+                variant,
+                "round-trip failed for {variant:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn error_type_unknown_raw_maps_to_invalid() {
+        assert_eq!(DuckDbErrorType::from_raw(9999), DuckDbErrorType::Invalid);
+    }
+
+    #[test]
+    fn error_type_distinct_raw_values() {
+        for (i, a) in ALL_VARIANTS.iter().enumerate() {
+            for b in ALL_VARIANTS.iter().skip(i + 1) {
+                assert_ne!(
+                    a.to_raw(),
+                    b.to_raw(),
+                    "variants {a:?} and {b:?} share a raw value"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn null_error_data_has_no_error() {
+        let err = unsafe { ErrorData::from_raw(std::ptr::null_mut()) };
+        assert!(err.is_null());
+        assert!(!err.has_error());
+        assert_eq!(err.error_type(), DuckDbErrorType::Invalid);
+        assert!(err.message().is_none());
+    }
+
+    #[test]
+    fn into_raw_forgets_handle() {
+        let err = unsafe { ErrorData::from_raw(std::ptr::null_mut()) };
+        let raw = err.into_raw();
+        assert!(raw.is_null());
+    }
+}

--- a/src/error_data.rs
+++ b/src/error_data.rs
@@ -60,8 +60,7 @@ use crate::error::ExtensionError;
 
 /// The category of a `DuckDB` error, mirroring `duckdb_error_type`.
 ///
-/// Unknown or future error categories map to [`DuckDbErrorType::Invalid`] via
-/// [`from_raw`][DuckDbErrorType::from_raw].
+/// Unknown or future error categories map to [`DuckDbErrorType::Invalid`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DuckDbErrorType {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Bound expressions (`DuckDB` 1.5.0+).
+//!
+//! [`Expression`] is an RAII wrapper around `DuckDB`'s `duckdb_expression` handle.
+//! Extension authors obtain one from a scalar function's *bind* callback via
+//! [`ScalarBindInfo::argument`][crate::scalar::ScalarBindInfo::argument], which
+//! lets the bind phase inspect each argument's static type and — when the
+//! argument is a constant — fold it to a concrete [`Value`].
+//!
+//! This is the canonical way to implement scalar functions whose behaviour
+//! depends on a constant argument (for example a format string or a precision)
+//! that should be validated or pre-computed once at bind time rather than on
+//! every row.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use quack_rs::scalar::ScalarBindInfo;
+//! use libduckdb_sys::duckdb_bind_info;
+//!
+//! unsafe extern "C" fn my_bind(info: duckdb_bind_info) {
+//!     let bind = unsafe { ScalarBindInfo::new(info) };
+//!     if let Some(arg) = unsafe { bind.argument(0) } {
+//!         // Inspect the argument's static return type at bind time.
+//!         let _ty = arg.return_type();
+//!         if arg.is_foldable() {
+//!             // With a `ClientContext`, `arg.fold(&ctx)` pre-computes the constant.
+//!         }
+//!     }
+//! }
+//! ```
+
+use libduckdb_sys::{
+    duckdb_destroy_expression, duckdb_expression, duckdb_expression_fold,
+    duckdb_expression_is_foldable, duckdb_expression_return_type, duckdb_value,
+};
+
+use crate::client_context::ClientContext;
+use crate::error_data::ErrorData;
+use crate::types::LogicalType;
+use crate::value::Value;
+
+/// RAII wrapper for a `duckdb_expression`.
+///
+/// Automatically destroyed when dropped.
+pub struct Expression {
+    raw: duckdb_expression,
+}
+
+impl Expression {
+    /// Wraps a raw `duckdb_expression` handle, taking ownership.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a valid `duckdb_expression` returned by a `DuckDB` API call
+    /// (e.g. `duckdb_scalar_function_bind_get_argument`). The caller must not
+    /// destroy the handle after this call.
+    #[inline]
+    #[must_use]
+    pub const unsafe fn from_raw(raw: duckdb_expression) -> Self {
+        Self { raw }
+    }
+
+    /// Returns the raw handle without consuming the `Expression`.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_expression {
+        self.raw
+    }
+
+    /// Returns `true` if the underlying handle is null.
+    #[inline]
+    #[must_use]
+    pub const fn is_null(&self) -> bool {
+        self.raw.is_null()
+    }
+
+    /// Returns the static return type of this expression, or `None` if the
+    /// handle is null.
+    #[must_use]
+    pub fn return_type(&self) -> Option<LogicalType> {
+        if self.raw.is_null() {
+            return None;
+        }
+        // SAFETY: self.raw is a non-null, valid duckdb_expression. The returned
+        // logical type is owned by the caller and freed by LogicalType on drop.
+        let raw = unsafe { duckdb_expression_return_type(self.raw) };
+        if raw.is_null() {
+            return None;
+        }
+        // SAFETY: raw is a non-null logical type handle owned by the caller.
+        Some(unsafe { LogicalType::from_raw(raw) })
+    }
+
+    /// Returns `true` if this expression is *foldable* — i.e. it is constant and
+    /// can be evaluated to a single [`Value`] via [`fold`][Expression::fold]
+    /// without per-row input.
+    #[must_use]
+    pub fn is_foldable(&self) -> bool {
+        if self.raw.is_null() {
+            return false;
+        }
+        // SAFETY: self.raw is a non-null, valid duckdb_expression.
+        unsafe { duckdb_expression_is_foldable(self.raw) }
+    }
+
+    /// Folds this (constant) expression into a single [`Value`].
+    ///
+    /// Only valid when [`is_foldable`][Expression::is_foldable] returns `true`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if folding fails (for example because
+    /// the expression is not constant).
+    pub fn fold(&self, context: &ClientContext) -> Result<Value, ErrorData> {
+        let mut out_value: duckdb_value = std::ptr::null_mut();
+        // SAFETY: self.raw and context.as_raw() are valid; out_value is a valid
+        // out-pointer that DuckDB writes an owned duckdb_value into.
+        let err_raw =
+            unsafe { duckdb_expression_fold(context.as_raw(), self.raw, &raw mut out_value) };
+        // SAFETY: duckdb_expression_fold returns an owned duckdb_error_data.
+        let err = unsafe { ErrorData::from_raw(err_raw) };
+        if err.has_error() {
+            // SAFETY: out_value may have been left null/invalid; destroy any value.
+            if !out_value.is_null() {
+                drop(unsafe { Value::from_raw(out_value) });
+            }
+            return Err(err);
+        }
+        // SAFETY: folding succeeded, so out_value is an owned duckdb_value.
+        Ok(unsafe { Value::from_raw(out_value) })
+    }
+}
+
+impl Drop for Expression {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            // SAFETY: self.raw is a valid duckdb_expression that we own.
+            unsafe { duckdb_destroy_expression(&raw mut self.raw) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_expression_is_null() {
+        let expr = unsafe { Expression::from_raw(std::ptr::null_mut()) };
+        assert!(expr.is_null());
+        assert!(!expr.is_foldable());
+        assert!(expr.return_type().is_none());
+    }
+
+    #[test]
+    fn size_of_expression_is_one_pointer() {
+        assert_eq!(
+            std::mem::size_of::<Expression>(),
+            std::mem::size_of::<usize>()
+        );
+    }
+}

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! File system access (`DuckDB` 1.5.0+).
+//!
+//! This module exposes `DuckDB`'s virtual file system (VFS) to extensions, so a
+//! custom table function, replacement scan, or copy function can read and write
+//! files through the *same* abstraction `DuckDB` uses internally. That means
+//! transparently honouring `httpfs` (`s3://`, `http://`), in-memory files, and
+//! any other registered file system — rather than reaching for `std::fs` and
+//! only ever seeing local disk.
+//!
+//! # Obtaining a [`FileSystem`]
+//!
+//! Get one from a [`ClientContext`] (which you can obtain from most function
+//! callbacks):
+//!
+//! ```rust,no_run
+//! use quack_rs::client_context::ClientContext;
+//! use quack_rs::file_system::{FileOpenOptions, FileSystem};
+//!
+//! # fn demo(ctx: &ClientContext) -> Option<()> {
+//! let fs = FileSystem::from_client_context(ctx)?;
+//! let opts = FileOpenOptions::read_only();
+//! let handle = fs.open(c"data.csv", &opts).ok()?;
+//! let mut buf = vec![0u8; handle.size().max(0) as usize];
+//! let _n = handle.read(&mut buf).ok()?;
+//! # Some(())
+//! # }
+//! ```
+
+use std::ffi::CStr;
+use std::os::raw::c_void;
+
+use libduckdb_sys::{
+    duckdb_client_context_get_file_system, duckdb_create_file_open_options,
+    duckdb_destroy_file_handle, duckdb_destroy_file_open_options, duckdb_destroy_file_system,
+    duckdb_file_flag, duckdb_file_flag_DUCKDB_FILE_FLAG_APPEND,
+    duckdb_file_flag_DUCKDB_FILE_FLAG_CREATE, duckdb_file_flag_DUCKDB_FILE_FLAG_CREATE_NEW,
+    duckdb_file_flag_DUCKDB_FILE_FLAG_READ, duckdb_file_flag_DUCKDB_FILE_FLAG_WRITE,
+    duckdb_file_handle, duckdb_file_handle_close, duckdb_file_handle_error_data,
+    duckdb_file_handle_read, duckdb_file_handle_seek, duckdb_file_handle_size,
+    duckdb_file_handle_sync, duckdb_file_handle_tell, duckdb_file_handle_write,
+    duckdb_file_open_options, duckdb_file_open_options_set_flag, duckdb_file_system,
+    duckdb_file_system_error_data, duckdb_file_system_open, DuckDBSuccess,
+};
+
+use crate::client_context::ClientContext;
+use crate::error_data::ErrorData;
+
+/// A file-open mode flag, mirroring `duckdb_file_flag`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FileFlag {
+    /// Open for reading.
+    Read,
+    /// Open for writing.
+    Write,
+    /// Create the file if it does not exist.
+    Create,
+    /// Create the file, failing if it already exists.
+    CreateNew,
+    /// Open in append mode.
+    Append,
+}
+
+impl FileFlag {
+    /// Converts to the `DuckDB` C API constant.
+    #[must_use]
+    const fn to_raw(self) -> duckdb_file_flag {
+        match self {
+            Self::Read => duckdb_file_flag_DUCKDB_FILE_FLAG_READ,
+            Self::Write => duckdb_file_flag_DUCKDB_FILE_FLAG_WRITE,
+            Self::Create => duckdb_file_flag_DUCKDB_FILE_FLAG_CREATE,
+            Self::CreateNew => duckdb_file_flag_DUCKDB_FILE_FLAG_CREATE_NEW,
+            Self::Append => duckdb_file_flag_DUCKDB_FILE_FLAG_APPEND,
+        }
+    }
+}
+
+/// RAII wrapper for `duckdb_file_open_options`.
+///
+/// Describes how a file should be opened. Automatically destroyed when dropped.
+pub struct FileOpenOptions {
+    options: duckdb_file_open_options,
+}
+
+impl FileOpenOptions {
+    /// Creates an empty set of file-open options.
+    #[must_use]
+    pub fn new() -> Self {
+        // SAFETY: duckdb_create_file_open_options allocates an owned handle.
+        let options = unsafe { duckdb_create_file_open_options() };
+        Self { options }
+    }
+
+    /// Creates options configured for read-only access.
+    #[must_use]
+    pub fn read_only() -> Self {
+        let opts = Self::new();
+        opts.set_flag(FileFlag::Read, true);
+        opts
+    }
+
+    /// Creates options configured for writing, creating the file if needed.
+    #[must_use]
+    pub fn write_create() -> Self {
+        let opts = Self::new();
+        opts.set_flag(FileFlag::Write, true);
+        opts.set_flag(FileFlag::Create, true);
+        opts
+    }
+
+    /// Sets a file-open flag, returning `true` on success.
+    pub fn set_flag(&self, flag: FileFlag, value: bool) -> bool {
+        if self.options.is_null() {
+            return false;
+        }
+        // SAFETY: self.options is a valid duckdb_file_open_options.
+        let state =
+            unsafe { duckdb_file_open_options_set_flag(self.options, flag.to_raw(), value) };
+        state == DuckDBSuccess
+    }
+
+    /// Returns the raw handle without consuming the options.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_file_open_options {
+        self.options
+    }
+}
+
+impl Default for FileOpenOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for FileOpenOptions {
+    fn drop(&mut self) {
+        if !self.options.is_null() {
+            // SAFETY: self.options is a valid handle that we own.
+            unsafe { duckdb_destroy_file_open_options(&raw mut self.options) };
+        }
+    }
+}
+
+/// RAII wrapper for a `duckdb_file_system`.
+///
+/// Automatically destroyed when dropped.
+pub struct FileSystem {
+    fs: duckdb_file_system,
+}
+
+impl FileSystem {
+    /// Obtains the file system associated with a [`ClientContext`].
+    ///
+    /// Returns `None` if `DuckDB` does not provide one.
+    #[must_use]
+    pub fn from_client_context(context: &ClientContext) -> Option<Self> {
+        // SAFETY: context.as_raw() is a valid duckdb_client_context.
+        let fs = unsafe { duckdb_client_context_get_file_system(context.as_raw()) };
+        if fs.is_null() {
+            None
+        } else {
+            Some(Self { fs })
+        }
+    }
+
+    /// Wraps a raw `duckdb_file_system` handle, taking ownership.
+    ///
+    /// # Safety
+    ///
+    /// `fs` must be a valid, non-null `duckdb_file_system` handle that the caller
+    /// no longer manages.
+    #[inline]
+    #[must_use]
+    pub const unsafe fn from_raw(fs: duckdb_file_system) -> Self {
+        Self { fs }
+    }
+
+    /// Returns the raw handle.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_file_system {
+        self.fs
+    }
+
+    /// Opens `path` with the given `options`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the file cannot be opened.
+    pub fn open(&self, path: &CStr, options: &FileOpenOptions) -> Result<FileHandle, ErrorData> {
+        let mut handle: duckdb_file_handle = std::ptr::null_mut();
+        // SAFETY: self.fs, path, and options.as_raw() are all valid; handle is a
+        // valid out-pointer.
+        let state = unsafe {
+            duckdb_file_system_open(self.fs, path.as_ptr(), options.as_raw(), &raw mut handle)
+        };
+        if state == DuckDBSuccess && !handle.is_null() {
+            // SAFETY: open succeeded, so handle is a valid owned file handle.
+            Ok(unsafe { FileHandle::from_raw(handle) })
+        } else {
+            Err(self.error_data())
+        }
+    }
+
+    /// Returns the structured error from the most recent failed operation.
+    #[must_use]
+    pub fn error_data(&self) -> ErrorData {
+        // SAFETY: self.fs is valid; the call returns an owned error data handle.
+        let raw = unsafe { duckdb_file_system_error_data(self.fs) };
+        // SAFETY: raw is an owned duckdb_error_data (possibly null).
+        unsafe { ErrorData::from_raw(raw) }
+    }
+}
+
+impl Drop for FileSystem {
+    fn drop(&mut self) {
+        if !self.fs.is_null() {
+            // SAFETY: self.fs is a valid handle that we own.
+            unsafe { duckdb_destroy_file_system(&raw mut self.fs) };
+        }
+    }
+}
+
+/// RAII wrapper for an open `duckdb_file_handle`.
+///
+/// Automatically closed and destroyed when dropped.
+pub struct FileHandle {
+    handle: duckdb_file_handle,
+}
+
+impl FileHandle {
+    /// Wraps a raw `duckdb_file_handle`, taking ownership.
+    ///
+    /// # Safety
+    ///
+    /// `handle` must be a valid, non-null `duckdb_file_handle` that the caller no
+    /// longer manages.
+    #[inline]
+    #[must_use]
+    pub const unsafe fn from_raw(handle: duckdb_file_handle) -> Self {
+        Self { handle }
+    }
+
+    /// Returns the raw handle.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_file_handle {
+        self.handle
+    }
+
+    /// Reads up to `buf.len()` bytes into `buf`, returning the number of bytes
+    /// read (0 at end of file).
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] on read failure.
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize, ErrorData> {
+        let size = i64::try_from(buf.len()).unwrap_or(i64::MAX);
+        // SAFETY: self.handle is valid; buf is writable for `size` bytes.
+        let n = unsafe {
+            duckdb_file_handle_read(self.handle, buf.as_mut_ptr().cast::<c_void>(), size)
+        };
+        if n < 0 {
+            Err(self.error_data())
+        } else {
+            Ok(usize::try_from(n).unwrap_or(0))
+        }
+    }
+
+    /// Writes up to `buf.len()` bytes from `buf`, returning the number written.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] on write failure.
+    pub fn write(&self, buf: &[u8]) -> Result<usize, ErrorData> {
+        let size = i64::try_from(buf.len()).unwrap_or(i64::MAX);
+        // SAFETY: self.handle is valid; buf is readable for `size` bytes.
+        let n =
+            unsafe { duckdb_file_handle_write(self.handle, buf.as_ptr().cast::<c_void>(), size) };
+        if n < 0 {
+            Err(self.error_data())
+        } else {
+            Ok(usize::try_from(n).unwrap_or(0))
+        }
+    }
+
+    /// Seeks to an absolute byte `position`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the seek fails.
+    pub fn seek(&self, position: u64) -> Result<(), ErrorData> {
+        let pos = i64::try_from(position).unwrap_or(i64::MAX);
+        // SAFETY: self.handle is valid.
+        let state = unsafe { duckdb_file_handle_seek(self.handle, pos) };
+        self.check(state)
+    }
+
+    /// Returns the current byte offset within the file.
+    #[must_use]
+    pub fn tell(&self) -> i64 {
+        // SAFETY: self.handle is valid.
+        unsafe { duckdb_file_handle_tell(self.handle) }
+    }
+
+    /// Returns the total size of the file in bytes.
+    #[must_use]
+    pub fn size(&self) -> i64 {
+        // SAFETY: self.handle is valid.
+        unsafe { duckdb_file_handle_size(self.handle) }
+    }
+
+    /// Flushes buffered writes to durable storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the sync fails.
+    pub fn sync(&self) -> Result<(), ErrorData> {
+        // SAFETY: self.handle is valid.
+        let state = unsafe { duckdb_file_handle_sync(self.handle) };
+        self.check(state)
+    }
+
+    /// Closes the file. The handle is still destroyed on drop.
+    ///
+    /// # Errors
+    ///
+    /// Returns the structured [`ErrorData`] if the close fails.
+    pub fn close(&self) -> Result<(), ErrorData> {
+        // SAFETY: self.handle is valid.
+        let state = unsafe { duckdb_file_handle_close(self.handle) };
+        self.check(state)
+    }
+
+    /// Returns the structured error from the most recent failed operation.
+    #[must_use]
+    pub fn error_data(&self) -> ErrorData {
+        // SAFETY: self.handle is valid; the call returns an owned error data.
+        let raw = unsafe { duckdb_file_handle_error_data(self.handle) };
+        // SAFETY: raw is an owned duckdb_error_data (possibly null).
+        unsafe { ErrorData::from_raw(raw) }
+    }
+
+    /// Converts a `duckdb_state` into a `Result`, reading the handle's error
+    /// data on failure.
+    fn check(&self, state: libduckdb_sys::duckdb_state) -> Result<(), ErrorData> {
+        if state == DuckDBSuccess {
+            Ok(())
+        } else {
+            Err(self.error_data())
+        }
+    }
+}
+
+impl Drop for FileHandle {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            // SAFETY: self.handle is a valid handle that we own.
+            unsafe { duckdb_destroy_file_handle(&raw mut self.handle) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_flag_distinct_raw_values() {
+        let flags = [
+            FileFlag::Read,
+            FileFlag::Write,
+            FileFlag::Create,
+            FileFlag::CreateNew,
+            FileFlag::Append,
+        ];
+        for (i, a) in flags.iter().enumerate() {
+            for b in flags.iter().skip(i + 1) {
+                assert_ne!(a.to_raw(), b.to_raw(), "{a:?} and {b:?} share a raw value");
+            }
+        }
+    }
+}

--- a/src/instance_cache.rs
+++ b/src/instance_cache.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Database instance cache (`DuckDB` 1.5.0+).
+//!
+//! An [`InstanceCache`] lets multiple connections share a single underlying
+//! `DuckDB` instance for a given database path. Opening the same path twice
+//! through the cache returns handles backed by the *same* instance, which avoids
+//! the "database is already open in another process/instance" conflict and saves
+//! the cost of re-initialising the database.
+//!
+//! This is primarily useful for extensions or host integrations that open
+//! secondary databases on behalf of a query.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use quack_rs::instance_cache::InstanceCache;
+//!
+//! # fn demo() -> Result<(), quack_rs::error::ExtensionError> {
+//! let cache = InstanceCache::new();
+//! // Returns a duckdb_database the caller owns and must close with duckdb_close.
+//! let db = cache.get_or_create(c"my.db", None)?;
+//! # let _ = db;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use libduckdb_sys::{
+    duckdb_config, duckdb_create_instance_cache, duckdb_database, duckdb_destroy_instance_cache,
+    duckdb_free, duckdb_get_or_create_from_cache, duckdb_instance_cache, DuckDBSuccess,
+};
+
+use crate::config::DbConfig;
+use crate::error::ExtensionError;
+
+/// RAII wrapper for a `duckdb_instance_cache`.
+///
+/// Automatically destroyed when dropped. Databases obtained from the cache
+/// remain valid until they are individually closed and the cache is dropped.
+pub struct InstanceCache {
+    cache: duckdb_instance_cache,
+}
+
+impl InstanceCache {
+    /// Creates a new, empty instance cache.
+    #[must_use]
+    pub fn new() -> Self {
+        // SAFETY: duckdb_create_instance_cache allocates an owned handle.
+        let cache = unsafe { duckdb_create_instance_cache() };
+        Self { cache }
+    }
+
+    /// Opens `path` through the cache, creating the instance if it does not yet
+    /// exist or returning a handle to the cached one if it does.
+    ///
+    /// Pass `config` to control how a freshly-created instance is configured; it
+    /// is ignored when an instance already exists for `path`.
+    ///
+    /// The returned `duckdb_database` is owned by the caller and **must** be
+    /// closed with `duckdb_close` when no longer needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ExtensionError`] carrying `DuckDB`'s message if the instance
+    /// cannot be opened or created.
+    pub fn get_or_create(
+        &self,
+        path: &CStr,
+        config: Option<&DbConfig>,
+    ) -> Result<duckdb_database, ExtensionError> {
+        let mut out_db: duckdb_database = std::ptr::null_mut();
+        let mut out_err: *mut c_char = std::ptr::null_mut();
+        let cfg: duckdb_config = config.map_or(std::ptr::null_mut(), DbConfig::as_raw);
+        // SAFETY: self.cache and path are valid; out_db and out_err are valid
+        // out-pointers; cfg is either null or a valid duckdb_config.
+        let state = unsafe {
+            duckdb_get_or_create_from_cache(
+                self.cache,
+                path.as_ptr(),
+                &raw mut out_db,
+                cfg,
+                &raw mut out_err,
+            )
+        };
+        if state == DuckDBSuccess && !out_db.is_null() {
+            return Ok(out_db);
+        }
+        let message = if out_err.is_null() {
+            "failed to open database from instance cache".to_owned()
+        } else {
+            // SAFETY: out_err is a valid null-terminated string allocated by DuckDB.
+            let msg = unsafe { CStr::from_ptr(out_err) }
+                .to_str()
+                .unwrap_or("failed to open database from instance cache")
+                .to_owned();
+            // SAFETY: out_err was allocated by DuckDB and must be freed.
+            unsafe { duckdb_free(out_err.cast()) };
+            msg
+        };
+        Err(ExtensionError::new(message))
+    }
+
+    /// Returns the raw handle.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_instance_cache {
+        self.cache
+    }
+}
+
+impl Default for InstanceCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for InstanceCache {
+    fn drop(&mut self) {
+        if !self.cache.is_null() {
+            // SAFETY: self.cache is a valid handle that we own.
+            unsafe { duckdb_destroy_instance_cache(&raw mut self.cache) };
+        }
+    }
+}
+
+#[cfg(all(test, feature = "bundled-test"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_in_memory_via_cache() {
+        // Ensure the dispatch table is populated.
+        let _db = crate::testing::InMemoryDb::open().unwrap();
+
+        let cache = InstanceCache::new();
+        // Empty path opens an in-memory database.
+        let result = cache.get_or_create(c"", None);
+        assert!(result.is_ok(), "get_or_create failed: {:?}", result.err());
+        let mut db = result.unwrap();
+        // SAFETY: db is a valid duckdb_database returned from the cache.
+        unsafe { libduckdb_sys::duckdb_close(&raw mut db) };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,16 @@
 //! | [`scaffold`] | Project generator for new extensions (no C++ glue needed) |
 //! | [`testing`] | Test harness for aggregate state logic |
 //! | [`prelude`] | Convenience re-exports of the most commonly used items |
+//! | `appender` | Bulk row appender (`duckdb-1-5` feature) |
 //! | `catalog` | Catalog entry lookup (`duckdb-1-5` feature) |
 //! | `client_context` | Client context access (`duckdb-1-5` feature) |
 //! | `config_option` | Extension-defined configuration options (`duckdb-1-5` feature) |
 //! | `copy_function` | Custom `COPY TO` handlers (`duckdb-1-5` feature) |
+//! | `error_data` | Structured error type + UTF-8 validation (`duckdb-1-5` feature) |
+//! | `expression` | Bound expression inspection / constant folding (`duckdb-1-5` feature) |
+//! | `file_system` | `DuckDB` virtual file system access (`duckdb-1-5` feature) |
+//! | `instance_cache` | Shared database instance cache (`duckdb-1-5` feature) |
+//! | `selection_vector` | Zero-copy row-index selection vectors (`duckdb-1-5` feature) |
 //! | `table_description` | Table metadata queries (`duckdb-1-5` feature) |
 //!
 //! ## Safety
@@ -92,7 +98,7 @@
 //!    or improved safety. When in doubt, prefer simplicity.
 //! 2. **No panics across FFI**: `unwrap()` is forbidden in FFI callbacks and entry points.
 //! 3. **Bounded version range**: `libduckdb-sys` uses `>=1.4.4, <2` to support `DuckDB` 1.4.x
-//!    and 1.5.x (including v1.5.1) while preventing silent adoption of breaking changes in
+//!    and 1.5.x (through v1.5.3) while preventing silent adoption of breaking changes in
 //!    future major releases.
 //! 4. **Testable business logic**: state structs have zero FFI dependencies.
 //!
@@ -145,6 +151,8 @@ pub mod warning;
 
 // DuckDB 1.5.0+ modules — gated behind the `duckdb-1-5` feature flag.
 #[cfg(feature = "duckdb-1-5")]
+pub mod appender;
+#[cfg(feature = "duckdb-1-5")]
 pub mod catalog;
 #[cfg(feature = "duckdb-1-5")]
 pub mod client_context;
@@ -153,20 +161,31 @@ pub mod config_option;
 #[cfg(feature = "duckdb-1-5")]
 pub mod copy_function;
 #[cfg(feature = "duckdb-1-5")]
+pub mod error_data;
+#[cfg(feature = "duckdb-1-5")]
+pub mod expression;
+#[cfg(feature = "duckdb-1-5")]
+pub mod file_system;
+#[cfg(feature = "duckdb-1-5")]
+pub mod instance_cache;
+#[cfg(feature = "duckdb-1-5")]
+pub mod selection_vector;
+#[cfg(feature = "duckdb-1-5")]
 pub mod table_description;
 
 /// The `DuckDB` C API version string required by [`duckdb_rs_extension_api_init`][libduckdb_sys::duckdb_rs_extension_api_init].
 ///
-/// This constant corresponds to `DuckDB` releases v1.4.x, v1.5.0, and v1.5.1.
-/// The C API version did **not** change between v1.5.0 and v1.5.1. If you are
-/// targeting a different `DuckDB` release, consult the `DuckDB` changelog for the
-/// C API version.
+/// This constant corresponds to every `DuckDB` release from v1.4.x through
+/// v1.5.3: the C extension API version has remained `v1.2.0` across all of them
+/// (it did **not** change in the v1.5.1, v1.5.2, or v1.5.3 patch releases). If
+/// you are targeting a different `DuckDB` release, consult the `DuckDB` changelog
+/// for the C API version.
 ///
 /// # Pitfall P2: C API version ≠ `DuckDB` release version
 ///
 /// The `-dv` flag passed to `append_extension_metadata.py` must be this value
 /// (`"v1.2.0"`), **not** the `DuckDB` release version (`"v1.4.4"` / `"v1.5.0"` /
-/// `"v1.5.1"`). Using the wrong value causes the metadata script to fail silently
+/// `"v1.5.3"`). Using the wrong value causes the metadata script to fail silently
 /// or produce incorrect metadata.
 ///
 /// See `LESSONS.md` → Pitfall P2 for full details.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -74,6 +74,17 @@
 //! | [`WarningSeverity`] | `warning` module |
 //! | [`DUCKDB_API_VERSION`] | crate root |
 //!
+//! ## `DuckDB` 1.5.0+ items (require the `duckdb-1-5` feature)
+//!
+//! | Item | From |
+//! |------|------|
+//! | `Appender` | `appender` module |
+//! | `ErrorData` / `DuckDbErrorType` | `error_data` module |
+//! | `Expression` | `expression` module |
+//! | `FileSystem` / `FileHandle` / `FileOpenOptions` / `FileFlag` | `file_system` module |
+//! | `SelectionVector` | `selection_vector` module |
+//! | `InstanceCache` | `instance_cache` module |
+//!
 //! # What is NOT included
 //!
 //! The following items are intentionally excluded from the prelude because they
@@ -138,6 +149,20 @@ pub use crate::copy_function::{
     CopyBindFn, CopyBindInfo, CopyFinalizeFn, CopyFinalizeInfo, CopyFunctionBuilder,
     CopyGlobalInitFn, CopyGlobalInitInfo, CopySinkFn, CopySinkInfo,
 };
+
+// DuckDB 1.5.0+ API surfaces (require the `duckdb-1-5` feature).
+#[cfg(feature = "duckdb-1-5")]
+pub use crate::appender::Appender;
+#[cfg(feature = "duckdb-1-5")]
+pub use crate::error_data::{DuckDbErrorType, ErrorData};
+#[cfg(feature = "duckdb-1-5")]
+pub use crate::expression::Expression;
+#[cfg(feature = "duckdb-1-5")]
+pub use crate::file_system::{FileFlag, FileHandle, FileOpenOptions, FileSystem};
+#[cfg(feature = "duckdb-1-5")]
+pub use crate::instance_cache::InstanceCache;
+#[cfg(feature = "duckdb-1-5")]
+pub use crate::selection_vector::SelectionVector;
 
 // Table functions
 pub use crate::table::{

--- a/src/scalar/info.rs
+++ b/src/scalar/info.rs
@@ -23,6 +23,9 @@ use libduckdb_sys::{
     duckdb_function_info, duckdb_scalar_function_get_extra_info, duckdb_scalar_function_set_error,
 };
 
+#[cfg(feature = "duckdb-1-5")]
+use crate::expression::Expression;
+
 /// Converts a `&str` to `CString` without panicking.
 #[mutants::skip] // private FFI helper — tested in replacement_scan::tests
 fn str_to_cstring(s: &str) -> CString {
@@ -183,6 +186,28 @@ impl ScalarBindInfo {
     pub unsafe fn get_argument(&self, index: u64) -> duckdb_expression {
         // SAFETY: self.info is valid per constructor contract; caller guarantees index.
         unsafe { duckdb_scalar_function_bind_get_argument(self.info, index) }
+    }
+
+    /// Returns the argument at `index` as an RAII [`Expression`], or `None` if
+    /// `DuckDB` returns a null handle.
+    ///
+    /// This is the ergonomic counterpart to [`get_argument`][Self::get_argument]:
+    /// the returned [`Expression`] is destroyed automatically on drop and exposes
+    /// safe accessors for the argument's return type and constant folding.
+    ///
+    /// # Safety
+    ///
+    /// `index` must be less than [`argument_count`][Self::argument_count].
+    #[must_use]
+    pub unsafe fn argument(&self, index: u64) -> Option<Expression> {
+        // SAFETY: self.info is valid per constructor contract; caller guarantees index.
+        let raw = unsafe { duckdb_scalar_function_bind_get_argument(self.info, index) };
+        if raw.is_null() {
+            None
+        } else {
+            // SAFETY: raw is a non-null, owned duckdb_expression handle.
+            Some(unsafe { Expression::from_raw(raw) })
+        }
     }
 
     /// Retrieves the extra-info pointer previously set via

--- a/src/selection_vector.rs
+++ b/src/selection_vector.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+//! Selection vectors (`DuckDB` 1.5.0+).
+//!
+//! A [`SelectionVector`] is a list of row indices used to logically reorder or
+//! filter a data vector without copying its payload — the building block behind
+//! `DuckDB`'s zero-copy filtering. Extensions that implement custom filtering or
+//! reordering in vectorized callbacks can allocate one, fill in the indices, and
+//! hand it to the relevant `DuckDB` vector operations.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use quack_rs::selection_vector::SelectionVector;
+//!
+//! // Select rows 3, 1, 4, 1, 5 (in that order) from a source vector.
+//! let mut sel = SelectionVector::new(5);
+//! sel.as_mut_slice().copy_from_slice(&[3, 1, 4, 1, 5]);
+//! assert_eq!(sel.len(), 5);
+//! ```
+
+use libduckdb_sys::{
+    duckdb_create_selection_vector, duckdb_destroy_selection_vector, duckdb_selection_vector,
+    duckdb_selection_vector_get_data_ptr, idx_t, sel_t,
+};
+
+/// RAII wrapper for a `duckdb_selection_vector`.
+///
+/// Owns `size` 32-bit row indices ([`sel_t`]). Automatically destroyed on drop.
+pub struct SelectionVector {
+    sel: duckdb_selection_vector,
+    len: usize,
+}
+
+impl SelectionVector {
+    /// Allocates a selection vector holding `size` indices.
+    ///
+    /// The indices are uninitialised; fill them via
+    /// [`as_mut_slice`][SelectionVector::as_mut_slice].
+    #[must_use]
+    pub fn new(size: usize) -> Self {
+        let raw_size = idx_t::try_from(size).unwrap_or(idx_t::MAX);
+        // SAFETY: duckdb_create_selection_vector allocates an owned handle.
+        let sel = unsafe { duckdb_create_selection_vector(raw_size) };
+        let len = if sel.is_null() { 0 } else { size };
+        Self { sel, len }
+    }
+
+    /// Returns the number of indices in this selection vector.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the selection vector holds no indices.
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the indices as a read-only slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[sel_t] {
+        if self.sel.is_null() || self.len == 0 {
+            return &[];
+        }
+        // SAFETY: self.sel is valid; the data pointer addresses `self.len` sel_t
+        // elements that live as long as the selection vector.
+        let ptr = unsafe { duckdb_selection_vector_get_data_ptr(self.sel) };
+        if ptr.is_null() {
+            return &[];
+        }
+        // SAFETY: ptr points to `self.len` valid, aligned sel_t values.
+        unsafe { std::slice::from_raw_parts(ptr, self.len) }
+    }
+
+    /// Returns the indices as a mutable slice for filling in.
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [sel_t] {
+        if self.sel.is_null() || self.len == 0 {
+            return &mut [];
+        }
+        // SAFETY: self.sel is valid; the data pointer addresses `self.len` sel_t
+        // elements that live as long as the selection vector.
+        let ptr = unsafe { duckdb_selection_vector_get_data_ptr(self.sel) };
+        if ptr.is_null() {
+            return &mut [];
+        }
+        // SAFETY: ptr points to `self.len` valid, aligned sel_t values and we hold
+        // a unique borrow of `self`.
+        unsafe { std::slice::from_raw_parts_mut(ptr, self.len) }
+    }
+
+    /// Returns the raw handle.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_selection_vector {
+        self.sel
+    }
+}
+
+impl Drop for SelectionVector {
+    fn drop(&mut self) {
+        if !self.sel.is_null() {
+            // SAFETY: self.sel is a valid handle that we own. This destroy variant
+            // takes the handle by value.
+            unsafe { duckdb_destroy_selection_vector(self.sel) };
+        }
+    }
+}
+
+#[cfg(all(test, feature = "bundled-test"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_indices() {
+        // Ensure the dispatch table is populated.
+        let _db = crate::testing::InMemoryDb::open().unwrap();
+
+        let mut sel = SelectionVector::new(4);
+        assert_eq!(sel.len(), 4);
+        assert!(!sel.is_empty());
+        sel.as_mut_slice().copy_from_slice(&[7, 0, 3, 1]);
+        assert_eq!(sel.as_slice(), &[7, 0, 3, 1]);
+    }
+}

--- a/src/testing/mock_vector.rs
+++ b/src/testing/mock_vector.rs
@@ -148,13 +148,13 @@ impl MockVectorWriter {
 
     /// Returns the number of allocated rows (including NULLs).
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.rows.len()
     }
 
     /// Returns `true` if no rows have been allocated.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.rows.is_empty()
     }
 
@@ -604,7 +604,7 @@ impl MockVectorReader {
 
     /// Returns the number of rows in this reader.
     #[must_use]
-    pub fn row_count(&self) -> usize {
+    pub const fn row_count(&self) -> usize {
         self.rows.len()
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -30,6 +30,10 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+#[cfg(feature = "duckdb-1-5")]
+use libduckdb_sys::{
+    duckdb_create_time_ns, duckdb_get_time_ns, duckdb_time_ns, duckdb_value_to_string,
+};
 use libduckdb_sys::{
     duckdb_destroy_value, duckdb_free, duckdb_get_bool, duckdb_get_double, duckdb_get_float,
     duckdb_get_hugeint, duckdb_get_int16, duckdb_get_int32, duckdb_get_int64, duckdb_get_int8,
@@ -393,6 +397,59 @@ impl Value {
         } else {
             self.as_i128()
         }
+    }
+
+    /// Creates a `TIME_NS` value (time of day with nanosecond precision) from a
+    /// raw nanosecond count (`DuckDB` 1.5.0+).
+    ///
+    /// Pairs with [`as_time_ns`][Value::as_time_ns] and the
+    /// [`TypeId::TimeNs`][crate::types::TypeId::TimeNs] column type.
+    #[cfg(feature = "duckdb-1-5")]
+    #[inline]
+    #[must_use]
+    pub fn time_ns(nanos: i64) -> Self {
+        // SAFETY: duckdb_create_time_ns accepts any nanosecond count and returns
+        // an owned duckdb_value.
+        let raw = unsafe { duckdb_create_time_ns(duckdb_time_ns { nanos }) };
+        Self { raw }
+    }
+
+    /// Extracts the value as a `TIME_NS` nanosecond count (`DuckDB` 1.5.0+).
+    ///
+    /// Returns 0 if the value is not a `TIME_NS`.
+    #[cfg(feature = "duckdb-1-5")]
+    #[inline]
+    #[must_use]
+    pub fn as_time_ns(&self) -> i64 {
+        // SAFETY: self.raw is valid per constructor contract.
+        unsafe { duckdb_get_time_ns(self.raw) }.nanos
+    }
+
+    /// Returns the canonical string representation of this value, as `DuckDB`
+    /// would render it (`DuckDB` 1.5.0+).
+    ///
+    /// Returns `None` if the handle is null or the rendered text is not valid
+    /// UTF-8. This is primarily useful for diagnostics and error messages, where
+    /// it works for any value type (not just VARCHAR).
+    #[cfg(feature = "duckdb-1-5")]
+    #[must_use]
+    pub fn display_string(&self) -> Option<String> {
+        if self.raw.is_null() {
+            return None;
+        }
+        // SAFETY: self.raw is a valid duckdb_value per constructor contract.
+        let c_str: *mut c_char = unsafe { duckdb_value_to_string(self.raw) };
+        if c_str.is_null() {
+            return None;
+        }
+        // SAFETY: c_str is a valid null-terminated string allocated by DuckDB.
+        let result = unsafe { CStr::from_ptr(c_str) }
+            .to_str()
+            .ok()
+            .map(str::to_owned);
+        // SAFETY: c_str was allocated by DuckDB and must be freed with duckdb_free.
+        unsafe { duckdb_free(c_str.cast()) };
+        result
     }
 
     /// Returns `true` if the underlying handle is null.

--- a/src/vector/struct_reader.rs
+++ b/src/vector/struct_reader.rs
@@ -61,7 +61,7 @@ impl StructReader {
     #[mutants::skip]
     #[must_use]
     #[inline]
-    pub fn field_count(&self) -> usize {
+    pub const fn field_count(&self) -> usize {
         self.fields.len()
     }
 

--- a/src/vector/struct_writer.rs
+++ b/src/vector/struct_writer.rs
@@ -69,7 +69,7 @@ impl StructWriter {
     #[mutants::skip]
     #[must_use]
     #[inline]
-    pub fn field_count(&self) -> usize {
+    pub const fn field_count(&self) -> usize {
         self.fields.len()
     }
 


### PR DESCRIPTION
## Summary

Brings the SDK up to **DuckDB 1.5.3** and — rather than a bare version bump —
wraps the large part of the DuckDB **1.5.x C extension API** that quack-rs had
not yet exposed: six new `duckdb-1-5`-gated modules plus `Value` / `Catalog` /
scalar-bind additions, all with rustdoc, a new book section, and a
documentation-accuracy sweep. Along the way it folds in the open Dependabot
`cc` bump and corrects the project's declared MSRV, which was inaccurate.

Investigation note: I diffed the actual C extension headers — the
function-pointer API (version `v1.2.0`) is unchanged from 1.5.2, so the headline
value is exposing 1.5.x surface the SDK hadn't wrapped, not anything unique to
the 1.5.3 patch (the one 1.5.3 C addition, `DUCKDB_TYPE_VARIANT`, is covered
under "Known follow-up").

**Suggested release: minor `0.13.0`** (additive public API; no breaking changes).

## Type of change

- [x] New feature (non-breaking, adds functionality)
- [x] Documentation update
- [x] CI / tooling / dependency update
- [ ] Bug fix / Breaking change / Refactoring

## New `duckdb-1-5` API (six modules)

| Module | Types | Purpose |
|--------|-------|---------|
| `error_data` | `ErrorData`, `DuckDbErrorType`, `check_valid_utf8` | Structured error type returned by several 1.5 APIs; UTF-8 validation |
| `expression` | `Expression` | Inspect / constant-fold scalar-function argument expressions at bind time |
| `file_system` | `FileSystem`, `FileHandle`, `FileOpenOptions`, `FileFlag` | Read/write through DuckDB's virtual file system (httpfs, in-memory, …) |
| `appender` | `Appender` | Bulk row insertion + the 1.5 additions (`clear`, `error_data`, `append_default_to_chunk`) |
| `selection_vector` | `SelectionVector` | Zero-copy row-index selection vectors |
| `instance_cache` | `InstanceCache` | Share one underlying database instance across opens |

Existing types extended (also `duckdb-1-5`):
- **`ScalarBindInfo::argument()`** now returns a safe `Expression` — closing a real gap where `get_argument` previously handed back a raw, unusable `duckdb_expression`.
- **`Value`**: `display_string()` (via `duckdb_value_to_string`) + `TIME_NS` accessors `time_ns()` / `as_time_ns()`.
- **`Catalog::type_name()`**.
- All new public types are re-exported from the `prelude` under `duckdb-1-5`.

Conventions followed throughout: RAII `Drop`, exhaustive `// SAFETY:` comments, SPDX headers on every new source file, no FFI-callback panics, `#[deny(unsafe_op_in_unsafe_fn)]` upheld.

## Dependencies

- **`duckdb` / `libduckdb-sys` 1.10502.0 → 1.10503.1** (DuckDB 1.5.2 → 1.5.3) in both lockfiles. The `>=1.4.4, <2` constraint already permitted it.
- **`cc` → 1.2.62** in both lockfiles — folds in Dependabot PR #89 (`patch-updates` group) and re-syncs the example lock's older `cc` (1.2.57). **Closes #89.**

## MSRV correction → 1.87.0

The declared `rust-version = "1.84.1"` was **wrong**: `libduckdb-sys` (1.5.x line, non-optional dep) is `edition = "2024"` / `rust-version = "1.85.1"`, so the crate has actually required Rust ≥ 1.85.1 since before this branch — `cargo +1.84.1 check` can't even parse the manifest. Corrected to **1.87.0** (modest headroom over the 1.85.1 floor; verified: 1.84.1 fails, 1.85.1 and 1.87.0 pass).

Two related fixes:
- **Latent CI bug:** the `MSRV` job had no `with: toolchain:`, so it silently ran on `stable` (via `rust-toolchain.toml`) instead of the pinned version — which is why the inaccurate floor never tripped CI. It now explicitly pins `toolchain: "1.87.0"`.
- **Clippy follow-on:** `Vec::len`/`is_empty` became `const` in Rust 1.87.0, so the MSRV bump made clippy's MSRV-aware `missing_const_for_fn` flag five pre-existing accessors — made them `const`.

## Documentation

- **New book section "DuckDB 1.5+ APIs"** — six dedicated guide pages, wired into `SUMMARY.md` (verified with `mdbook build` 0.4.40; all links resolve).
- **Corrected the VARIANT "Known Limitations" entry** (now false): `DUCKDB_TYPE_VARIANT` (41) landed in DuckDB 1.5.3 and `GEOMETRY` (40) in 1.5.x.
- Refreshed `docs/architecture.md`, `docs/ffi-reference.md`, the `TypeId` reference, `CONTRIBUTING`/book source trees, and `Cargo.toml` feature docs; added a superseded banner to the 1.5.1 evaluation doc; updated `CHANGELOG.md` + book changelog.

## Known follow-up (intentionally not in this PR)

**`TypeId::Variant` / `TypeId::Geometry`** — these enum values now exist in the C API, but they postdate the `duckdb-1-5` feature's 1.5.0 floor (`VARIANT` needs 1.5.3). Exposing them safely needs a version-gating decision (raise the floor or add a finer gate), so it's documented in Known Limitations rather than shipped here.

## Verification (run locally)

- `cargo test --features bundled-test,duckdb-1-5` — 521 lib + 135 doctest + integration, **0 failures**
- `cargo clippy --all-targets -- -D warnings` (default) **and** `--features duckdb-1-5` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features duckdb-1-5` — clean
- `cargo fmt --check` — clean
- `cargo +1.87.0 check` (default + `duckdb-1-5`) — clean; `cargo +1.84.1 check` correctly fails (proves the floor)
- `mdbook build` (0.4.40) — clean

## Checklist

### Code quality
- [x] `cargo test --all-targets` passes (default, `bundled-test`, `duckdb-1-5`)
- [x] `cargo clippy --all-targets -- -D warnings` passes (default + `duckdb-1-5`)
- [x] `cargo fmt` applied (no diff)
- [x] `cargo doc --no-deps` builds without warnings
- [x] All `unsafe` blocks have a `// SAFETY:` comment
- [x] SPDX header on every new source file (book `.md` pages follow the existing no-header book convention)
- [x] No file exceeds 500 lines (largest new: `error_data.rs`, 494)

### Testing
- [x] New code has tests (enum round-trips, null/handle handling, and `bundled-test` FFI smoke tests for `selection_vector` / `instance_cache` / `appender`)
- [ ] `cargo mutants` — not run in this pass (happy to run if you'd like)

### Documentation
- [x] Public API changes documented in rustdoc
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Book updated (new "DuckDB 1.5+ APIs" section + reference refresh)
- [x] No new FFI pitfall discovered (N/A)

### Safety
- [x] No new panics in FFI callback paths
- [x] No new paths that could cross the FFI boundary with an unwinding panic
- [x] `#[deny(unsafe_op_in_unsafe_fn)]` remains satisfied

---
_Generated by [Claude Code](https://claude.ai/code/session_019iymWpuifHt7NqDApMsxUK)_