### PR TITLE
Release v0.13.0: Variant/Geometry, error_data polish, CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - run: cargo test --all-targets --features bundled-test
 
   test-duckdb-1-5:
-    name: Test duckdb-1-5 feature
+    name: Test duckdb-1-5 / duckdb-1-5-3 features
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -74,6 +74,9 @@ jobs:
       - run: cargo check --all-targets --features duckdb-1-5
       - run: cargo test --all-targets --features duckdb-1-5
       - run: cargo clippy --all-targets --features duckdb-1-5 -- -D warnings
+      - run: cargo check --all-targets --features duckdb-1-5-3
+      - run: cargo test --all-targets --features duckdb-1-5-3
+      - run: cargo clippy --all-targets --features duckdb-1-5-3 -- -D warnings
 
   clippy:
     name: Clippy
@@ -100,7 +103,7 @@ jobs:
           toolchain: beta
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo clippy --all-targets --features duckdb-1-5 -- -D warnings
+      - run: cargo clippy --all-targets --features duckdb-1-5-3 -- -D warnings
 
   fmt:
     name: Format
@@ -119,11 +122,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      # Use --features duckdb-1-5 instead of --all-features because
-      # bundled-test requires DuckDB headers from libduckdb-sys, which may
+      # Use --features duckdb-1-5-3 (implies duckdb-1-5) instead of --all-features
+      # because bundled-test requires DuckDB headers from libduckdb-sys, which may
       # not be compiled yet when the build script runs (build scripts only
       # wait for [build-dependencies], not [dependencies]).
-      - run: cargo doc --no-deps --features duckdb-1-5
+      - run: cargo doc --no-deps --features duckdb-1-5-3
         env:
           RUSTDOCFLAGS: "-D warnings"
 
@@ -268,6 +271,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Test (nightly, informational)
         run: cargo test --all-targets

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -143,18 +143,18 @@ jobs:
       - name: Determine changed files
         id: changed
         run: |
-          FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'src/**/*.rs')
-          FILE_COUNT=$(echo "$FILES" | grep -c . 2>/dev/null || echo 0)
+          FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'src/**/*.rs' | sort -u)
+          FILE_COUNT=$(printf '%s\n' "$FILES" | grep -c . 2>/dev/null || echo 0)
 
           if [ -z "$FILES" ] || [ "$FILE_COUNT" -eq 0 ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No Rust source files changed in src/ — mutation testing will be skipped."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "files=$(echo "$FILES" | tr '\n' ',')" >> "$GITHUB_OUTPUT"
+            echo "files=$(printf '%s\n' "$FILES" | tr '\n' ',')" >> "$GITHUB_OUTPUT"
             echo ""
-            echo "Changed files to mutate (${FILE_COUNT}):"
-            echo "$FILES" | sed 's/^/  /'
+            echo "Changed files (${FILE_COUNT}):"
+            printf '%s\n' "$FILES" | sed 's/^/  /'
           fi
 
       - name: Run mutation tests on changed files
@@ -163,16 +163,39 @@ jobs:
         run: |
           echo "::group::cargo-mutants execution log"
 
-          IFS=',' read -ra FILE_ARRAY <<< "${{ steps.changed.outputs.files }}"
-          GLOB_ARGS=""
-          for f in "${FILE_ARRAY[@]}"; do
-            if [ -n "$f" ]; then
-              GLOB_ARGS="$GLOB_ARGS --file $f"
-            fi
+          # `--file` for each changed source file.
+          IFS=',' read -ra CHANGED <<< "${{ steps.changed.outputs.files }}"
+          ARGS=()
+          for f in "${CHANGED[@]}"; do
+            [ -n "$f" ] && ARGS+=(--file "$f")
           done
 
+          # Re-apply mutants.toml `exclude_globs` as CLI `--exclude` flags.
+          # `--file` bypasses config excludes, so without this an edit to an
+          # excluded module (test helper / FFI wrapper) gets mutated and reports
+          # unkillable "missed" mutants. mutants.toml stays the single source of
+          # truth; `--exclude` wins over `--file` for the same path.
+          while IFS= read -r glob; do
+            [ -n "$glob" ] && ARGS+=(--exclude "$glob")
+          done < <(sed -n '/^exclude_globs = \[/,/^]/p' mutants.toml | grep -oE '"[^"]+"' | tr -d '"')
+
+          # `--features duckdb-1-5-3` MUST be explicit: cargo-mutants does not
+          # apply mutants.toml `features` to this invocation, so without it the
+          # duckdb-1-5-gated code (type_id's 1.5 type arms, the whole error_data
+          # module) is cfg'd out — its mutations would be inert and reported as
+          # false "missed".
+          #
+          # `--cargo-arg=--lib` kills mutants with FAST, deterministic *unit*
+          # tests: the bundled-DuckDB integration suite is slow, and run
+          # per-mutant under --jobs its contention misclassifies caught mutants.
+          # `--exclude-re ErrorData` drops the error_data FFI methods (ErrorData /
+          # check_valid_utf8) that need a live runtime; the pure DuckDbErrorType
+          # logic stays mutation-tested.
           set +e
-          cargo mutants $GLOB_ARGS \
+          cargo mutants "${ARGS[@]}" \
+            --features duckdb-1-5-3 \
+            --cargo-arg=--lib \
+            --exclude-re 'ErrorData' \
             --output mutants.out \
             --timeout 120 \
             --jobs 4 2>&1 | tee /tmp/mutants-run.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target/
 examples/hello-ext/target/
 book/book/
+mutants.out/
+mutants.out.old/
 .DS_Store
 *.swp
 *.swo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,28 @@ new to 1.5.3 specifically.
   crate; v0.12.1 was in fact already on crates.io) and bumped install-example
   version references throughout the README, book, and scaffold template to `0.13`.
 
+### CI
+
+- **docs.rs now builds with `duckdb-1-5-3`** (`[package.metadata.docs.rs]`), so
+  the feature-gated modules (`appender`, `error_data`, `file_system`, …) and the
+  new `TypeId` variants render on docs.rs and the README's docs.rs links resolve.
+  Previously docs.rs built the empty default feature set and omitted them.
+- **CI exercises the `duckdb-1-5-3` feature** — the feature job now runs
+  `check` / `test` / `clippy` for `duckdb-1-5-3` alongside `duckdb-1-5`, and the
+  `Clippy (beta)` and `doc` jobs use `duckdb-1-5-3`.
+- **Fixed the `Nightly` CI job silently running stable** — the SHA-pinned
+  `dtolnay/rust-toolchain` step lacked `with: toolchain: nightly`, so it fell
+  back to the `rust-toolchain.toml` stable channel (the same class of bug
+  previously fixed for the MSRV job).
+- **Mutation testing scoped to testable code** — DuckDB FFI-wrapper modules
+  whose methods require a live runtime (and whose tests are `bundled-test`-gated
+  or absent) are excluded from `cargo mutants`, since their mutants can't be
+  killed by unit tests. This extends the existing exclusion pattern to the 1.5.x
+  wrappers — `expression`, `file_system`, `appender`, `selection_vector`,
+  `instance_cache`, `table_description`, and the scalar/copy `*Info` accessors.
+  Pure-logic code (e.g. `DuckDbErrorType`, the `TypeId` conversions) stays in
+  scope. The mutants feature set is bumped to `duckdb-1-5-3`.
+
 ## [0.12.1] - 2026-05-01
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-24
+
 ### Added
 
 New safe wrappers for the `DuckDB` 1.5.0+ C extension API, all gated behind the
-`duckdb-1-5` feature. DuckDB 1.5.3's C extension *function-pointer* API (version
-`v1.2.0`) is unchanged from 1.5.2; the one new C addition — the
-`DUCKDB_TYPE_VARIANT` (41) type-enum value — is intentionally **not** surfaced
-yet (see Known Limitations for the version-floor reasoning). So the additions
-below mostly expose 1.5.x capabilities the SDK had not previously wrapped rather
-than anything new to 1.5.3 specifically.
+`duckdb-1-5` feature, plus a new `duckdb-1-5-3` feature that surfaces the two
+DuckDB 1.5.3 type-enum values. DuckDB 1.5.3's C extension *function-pointer* API
+(version `v1.2.0`) is unchanged from 1.5.2; the one new C addition — the
+`DUCKDB_TYPE_VARIANT` (41) type-enum value — is now exposed as `TypeId::Variant`
+behind the `duckdb-1-5-3` feature (see below). So the additions below mostly
+expose 1.5.x capabilities the SDK had not previously wrapped rather than anything
+new to 1.5.3 specifically.
 
 - **`error_data` module** — `ErrorData`, an RAII wrapper over
   `duckdb_error_data` (the structured error type returned by several 1.5 APIs).
@@ -46,6 +49,22 @@ than anything new to 1.5.3 specifically.
   or a storage extension's name).
 - All new public types are re-exported from the `prelude` behind the
   `duckdb-1-5` feature.
+- **`duckdb-1-5-3` feature + `TypeId::Variant` / `TypeId::Geometry`** — a new
+  feature flag (`duckdb-1-5-3`, which implies `duckdb-1-5`) exposes the
+  `DUCKDB_TYPE_VARIANT` (41, added in DuckDB 1.5.3) and `DUCKDB_TYPE_GEOMETRY`
+  (40) type-enum values as `TypeId::Variant` and `TypeId::Geometry`, with the
+  matching `to_duckdb_type` / `from_duckdb_type` / `sql_name` / `Display`
+  coverage. It is a separate gate because these constants postdate the
+  `duckdb-1-5` feature's 1.5.0 floor and require `libduckdb-sys >= 1.10503.1`;
+  keeping them out of `duckdb-1-5` preserves compatibility for consumers pinned
+  to libduckdb-sys 1.5.0–1.5.2.
+- **`ErrorData` is now a first-class error type** — implements
+  `std::fmt::Display` and `std::error::Error`, gains a structured `Debug` impl,
+  and converts into `ExtensionError` via `From` (alongside the existing
+  `into_extension_error`) so it propagates through `?`. `DuckDbErrorType` now
+  implements `Display` (backed by a new `pub const fn as_str`).
+- **`TableDescription::as_raw()`** — exposes the raw handle, matching the
+  accessor convention of the other 1.5 wrappers.
 
 ### Changed
 
@@ -69,6 +88,19 @@ than anything new to 1.5.3 specifically.
   and all docs/badges are updated to **1.87.0** — a small headroom margin above
   the 1.85.1 floor.
 
+### Fixed
+
+- **`TypeId::from_duckdb_type` no longer panics on the `duckdb-1-5` type-enum
+  values.** It previously recognised only the base (1.4) values and `panic!`ed on
+  everything else — including the `duckdb-1-5` values (`TIME_NS`, `ANY`,
+  `BIGNUM`/`VARINT`, `SQLNULL`, `INTEGER_LITERAL`, `STRING_LITERAL`). Because the
+  public `LogicalType::get_type_id()` calls it, inspecting such a type inside a
+  bind callback could panic across the FFI boundary (Pitfall L3). It now maps
+  every variant available in the active feature set (plus the `duckdb-1-5-3`
+  `GEOMETRY` / `VARIANT` values when that feature is enabled).
+- **`TableDescription`'s `Drop` now null-checks the handle** before destroying
+  it, matching every other RAII wrapper in the crate.
+
 ### Documentation
 
 - **New book section "DuckDB 1.5+ APIs"** — dedicated guide pages for the
@@ -76,10 +108,17 @@ than anything new to 1.5.3 specifically.
   `instance_cache` modules, wired into `SUMMARY.md`.
 - Refreshed the reference docs (`docs/architecture.md`, `docs/ffi-reference.md`,
   the `TypeId` reference, `CONTRIBUTING.md`/book source trees) to cover the new
-  modules, and corrected the now-resolved VARIANT/GEOMETRY entries in
-  `Known Limitations` (these type-enum values now exist in the C API as of
-  DuckDB 1.5.3 / 1.5.x; `TypeId::Variant`/`Geometry` remain a tracked follow-up
-  pending a version-floor decision).
+  modules, and updated the VARIANT/GEOMETRY entries in `Known Limitations`,
+  `concepts/types.md`, and the `TypeId` reference to document the new
+  `duckdb-1-5-3` gate (previously tracked as a follow-up).
+- Added `// SAFETY:` comments to previously-undocumented `unsafe` blocks in the
+  `get_client_context` accessors (`scalar`, `copy_function`) and
+  `TableDescription::create`, and SPDX headers to `benches/interval_bench.rs` and
+  the test submodule files — closing the last gaps against the crate's own
+  "every file / every `unsafe` block" conventions.
+- Corrected the README install note (it claimed v0.11.0 was the latest published
+  crate; v0.12.1 was in fact already on crates.io) and bumped install-example
+  version references throughout the README, book, and scaffold template to `0.13`.
 
 ## [0.12.1] - 2026-05-01
 
@@ -993,7 +1032,8 @@ the workspace `Cargo.lock` and `examples/hello-ext/Cargo.lock`.
 - CI pipeline: check, test, clippy, fmt, doc, MSRV, bench-compile
 - `SECURITY.md` vulnerability disclosure policy
 
-[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/tomtom215/quack-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/tomtom215/quack-rs/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "cc",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quack-rs"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.87.0"
 authors = ["Tom F. <tomf@tomtomtech.net>"]
@@ -59,6 +59,23 @@ crate-type = ["rlib"]
 ## - `Value::display_string` and `TIME_NS` accessors (`Value::time_ns` / `as_time_ns`)
 duckdb-1-5 = []
 
+## Enables wrappers layered on top of `duckdb-1-5` that require DuckDB **1.5.3+**.
+## Implies (and re-enables) `duckdb-1-5`.
+##
+## Requires `libduckdb-sys >= 1.10503.1` (DuckDB 1.5.3) to be resolved by Cargo:
+## the gated items reference C type-enum constants that do not exist in
+## libduckdb-sys 1.5.0–1.5.2, so enabling this feature against an older binding
+## is a compile error (by design — it surfaces the version mismatch immediately).
+## This is the same soft-contract style as `duckdb-1-5` (which targets 1.5.0).
+##
+## Gates:
+## - `TypeId::Variant` (`DUCKDB_TYPE_VARIANT`, 41) — added to the C type enum in
+##   DuckDB 1.5.3.
+## - `TypeId::Geometry` (`DUCKDB_TYPE_GEOMETRY`, 40) — present earlier in the
+##   1.5.x line, but gated here at the 1.5.3 floor so one feature covers both new
+##   type-enum values behind a single, verifiable version requirement.
+duckdb-1-5-3 = ["duckdb-1-5"]
+
 ## Links a bundled copy of DuckDB for integration testing.
 ##
 ## When this feature is enabled, the `testing::InMemoryDb` helper becomes available.
@@ -81,7 +98,7 @@ duckdb-1-5 = []
 ##
 ## ```toml
 ## [dev-dependencies]
-## quack-rs = { version = "0.11", features = ["bundled-test"] }
+## quack-rs = { version = "0.13", features = ["bundled-test"] }
 ## ```
 bundled-test = ["dep:duckdb"]
 
@@ -131,3 +148,11 @@ module_name_repetitions = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 return_self_not_must_use = "allow"
+
+[package.metadata.docs.rs]
+# Render the full API on docs.rs — including the `duckdb-1-5` / `duckdb-1-5-3`
+# feature-gated modules and `TypeId` variants — so the documentation (and the
+# README's docs.rs links) resolve. Without this, docs.rs builds the empty default
+# feature set and every feature-gated item would be missing. `bundled-test` is
+# intentionally excluded (it compiles DuckDB from source).
+features = ["duckdb-1-5-3"]

--- a/README.md
+++ b/README.md
@@ -121,14 +121,9 @@ See [`LESSONS.md`](./LESSONS.md) for full analysis of each pitfall.
 
 ```toml
 [dependencies]
-quack-rs = "0.11"
+quack-rs = "0.13"
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
 ```
-
-> The latest crate published to [crates.io](https://crates.io/crates/quack-rs)
-> is **v0.11.0**. Version v0.12.1 is prepared in this repository but has not
-> yet been published. Until the v0.12.1 release workflow runs,
-> `cargo add quack-rs` resolves to `0.11.0`.
 
 > **DuckDB compatibility**: `quack-rs` supports DuckDB **1.4.x and 1.5.x**.
 > Both releases expose the same C API version (`v1.2.0`), confirmed by E2E tests
@@ -811,12 +806,12 @@ DuckDB v1.5.1 introduced the `VARIANT` type (Iceberg v3 support); it landed in
 the C type enum as `DUCKDB_TYPE_VARIANT` (41) in **DuckDB 1.5.3**. The
 `GEOMETRY` type (`DUCKDB_TYPE_GEOMETRY`, 40) is also present in the C API.
 
-`quack-rs` does **not yet** expose `TypeId::Variant` or `TypeId::Geometry`. The
-reason is version-floor, not capability: the `duckdb-1-5` feature is defined
-against DuckDB **1.5.0**, but these constants only exist in later 1.5.x bindings
-(`VARIANT` requires 1.5.3). Exposing them safely needs either a 1.5.3 floor or a
-finer-grained feature gate — a deliberate versioning decision tracked for a
-follow-up release.
+`quack-rs` exposes these as `TypeId::Variant` and `TypeId::Geometry` behind the
+**`duckdb-1-5-3`** feature flag. That feature layers on top of `duckdb-1-5` and
+requires `libduckdb-sys >= 1.10503.1` (DuckDB 1.5.3). It is a separate gate
+because these type-enum constants postdate the `duckdb-1-5` feature's 1.5.0
+floor (`VARIANT` was added in 1.5.3), so keeping them out of `duckdb-1-5`
+preserves compatibility for consumers pinned to libduckdb-sys 1.5.0–1.5.2.
 
 > For the full list of resolved and open limitations, see the
 > [Known Limitations](https://quack-rs.com/reference/known-limitations.html) reference page.
@@ -826,6 +821,17 @@ follow-up release.
 ## Changelog
 
 See [`CHANGELOG.md`](./CHANGELOG.md) for the full version history.
+
+**v0.13.0** (2026-05-24) — DuckDB **1.5.3** bump (`libduckdb-sys`/`duckdb`
+1.10503.1), MSRV corrected to **1.87.0**, and six new `duckdb-1-5`-gated modules
+(`error_data`, `expression`, `file_system`, `appender`, `selection_vector`,
+`instance_cache`) plus `Value`/`Catalog` additions. Adds a new **`duckdb-1-5-3`**
+feature exposing `TypeId::Variant` and `TypeId::Geometry` (the DuckDB 1.5.3
+type-enum values, gated separately to preserve libduckdb-sys 1.5.0–1.5.2
+compatibility). `ErrorData` now implements `Display` + `std::error::Error`;
+`DuckDbErrorType` implements `Display`. Fixes a latent panic-across-FFI in
+`TypeId::from_duckdb_type` (it now maps the `duckdb-1-5` type values instead of
+panicking, e.g. via `LogicalType::get_type_id()`).
 
 **v0.12.1** (2026-05-01) — Security/maintenance patch. Closes nine
 GitHub Dependabot alerts (two High, seven Low) across both lockfiles by

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,9 @@
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.13.x  | Yes                |
 | 0.12.x  | Yes                |
-| 0.11.x  | Yes                |
+| 0.11.x  | No (end-of-life)   |
 | 0.10.x  | No (end-of-life)   |
 | 0.9.x   | No (end-of-life)   |
 | 0.8.x   | No (end-of-life)   |

--- a/benches/interval_bench.rs
+++ b/benches/interval_bench.rs
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
 //! Benchmarks for interval conversion utilities.
 //!
 //! Run with: `cargo bench`

--- a/book/src/concepts/types.md
+++ b/book/src/concepts/types.md
@@ -7,8 +7,8 @@ quack-rs provides `TypeId` and `LogicalType` to bridge Rust types and DuckDB col
 ## `TypeId`
 
 `TypeId` is an ergonomic enum covering DuckDB's column types (the `GEOMETRY` and
-`VARIANT` types added in DuckDB 1.5.x are not yet exposed — see
-[Known Limitations](../reference/known-limitations.md)):
+`VARIANT` types added in DuckDB 1.5.x are exposed behind the `duckdb-1-5-3`
+feature — see [Known Limitations](../reference/known-limitations.md)):
 
 ```rust
 use quack_rs::types::TypeId;
@@ -52,6 +52,8 @@ TypeId::Varint           // duckdb-1-5
 TypeId::SqlNull          // duckdb-1-5
 TypeId::IntegerLiteral   // duckdb-1-5
 TypeId::StringLiteral    // duckdb-1-5
+TypeId::Geometry         // duckdb-1-5-3
+TypeId::Variant          // duckdb-1-5-3
 ```
 
 `TypeId` is `Copy`, `Clone`, `Debug`, `PartialEq`, `Eq`, and `Display`.

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -6,7 +6,7 @@ Add the following to your extension's `Cargo.toml`:
 
 ```toml
 [dependencies]
-quack-rs = "0.11"
+quack-rs = "0.13"
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
 ```
 

--- a/book/src/getting-started/quick-start.md
+++ b/book/src/getting-started/quick-start.md
@@ -17,7 +17,7 @@ In your extension's `Cargo.toml`:
 
 ```toml
 [dependencies]
-quack-rs = "0.11"
+quack-rs = "0.13"
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
 
 [lib]

--- a/book/src/publishing.md
+++ b/book/src/publishing.md
@@ -201,7 +201,7 @@ name = "my_extension"       # Must match description.yml `name`
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-quack-rs = "0.11"
+quack-rs = "0.13"
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
 
 [profile.release]

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,15 +10,18 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-05-24
+
 ### Added
 
 New safe wrappers for the `DuckDB` 1.5.0+ C extension API, all gated behind the
-`duckdb-1-5` feature. DuckDB 1.5.3's C extension *function-pointer* API (version
-`v1.2.0`) is unchanged from 1.5.2; the one new C addition — the
-`DUCKDB_TYPE_VARIANT` (41) type-enum value — is intentionally **not** surfaced
-yet (see Known Limitations for the version-floor reasoning). So the additions
-below mostly expose 1.5.x capabilities the SDK had not previously wrapped rather
-than anything new to 1.5.3 specifically.
+`duckdb-1-5` feature, plus a new `duckdb-1-5-3` feature that surfaces the two
+DuckDB 1.5.3 type-enum values. DuckDB 1.5.3's C extension *function-pointer* API
+(version `v1.2.0`) is unchanged from 1.5.2; the one new C addition — the
+`DUCKDB_TYPE_VARIANT` (41) type-enum value — is now exposed as `TypeId::Variant`
+behind the `duckdb-1-5-3` feature (see below). So the additions below mostly
+expose 1.5.x capabilities the SDK had not previously wrapped rather than anything
+new to 1.5.3 specifically.
 
 - **`error_data` module** — `ErrorData`, an RAII wrapper over
   `duckdb_error_data` (the structured error type returned by several 1.5 APIs).
@@ -49,6 +52,21 @@ than anything new to 1.5.3 specifically.
   or a storage extension's name).
 - All new public types are re-exported from the `prelude` behind the
   `duckdb-1-5` feature.
+- **`duckdb-1-5-3` feature + `TypeId::Variant` / `TypeId::Geometry`** — a new
+  feature flag (`duckdb-1-5-3`, which implies `duckdb-1-5`) exposes the
+  `DUCKDB_TYPE_VARIANT` (41, added in DuckDB 1.5.3) and `DUCKDB_TYPE_GEOMETRY`
+  (40) type-enum values as `TypeId::Variant` and `TypeId::Geometry`, with full
+  `to_duckdb_type` / `from_duckdb_type` / `sql_name` / `Display` coverage. It is a
+  separate gate because these constants postdate the `duckdb-1-5` feature's 1.5.0
+  floor and require `libduckdb-sys >= 1.10503.1`; keeping them out of `duckdb-1-5`
+  preserves compatibility for consumers pinned to libduckdb-sys 1.5.0–1.5.2.
+- **`ErrorData` is now a first-class error type** — implements
+  `std::fmt::Display` and `std::error::Error`, gains a structured `Debug` impl,
+  and converts into `ExtensionError` via `From` (alongside the existing
+  `into_extension_error`) so it propagates through `?`. `DuckDbErrorType` now
+  implements `Display` (backed by a new `pub const fn as_str`).
+- **`TableDescription::as_raw()`** — exposes the raw handle, matching the
+  accessor convention of the other 1.5 wrappers.
 
 ### Changed
 
@@ -72,6 +90,19 @@ than anything new to 1.5.3 specifically.
   and all docs/badges are updated to **1.87.0** — a small headroom margin above
   the 1.85.1 floor.
 
+### Fixed
+
+- **`TypeId::from_duckdb_type` no longer panics on the `duckdb-1-5` type-enum
+  values.** It previously recognised only the base (1.4) values and `panic!`ed on
+  everything else — including the `duckdb-1-5` values (`TIME_NS`, `ANY`,
+  `BIGNUM`/`VARINT`, `SQLNULL`, `INTEGER_LITERAL`, `STRING_LITERAL`). Because the
+  public `LogicalType::get_type_id()` calls it, inspecting such a type inside a
+  bind callback could panic across the FFI boundary (Pitfall L3). It now maps
+  every variant available in the active feature set (plus the `duckdb-1-5-3`
+  `GEOMETRY` / `VARIANT` values when that feature is enabled).
+- **`TableDescription`'s `Drop` now null-checks the handle** before destroying
+  it, matching every other RAII wrapper in the crate.
+
 ### Documentation
 
 - **New book section "DuckDB 1.5+ APIs"** — dedicated guide pages for the
@@ -79,10 +110,16 @@ than anything new to 1.5.3 specifically.
   `instance_cache` modules, wired into `SUMMARY.md`.
 - Refreshed the reference docs (`docs/architecture.md`, `docs/ffi-reference.md`,
   the `TypeId` reference, `CONTRIBUTING.md`/book source trees) to cover the new
-  modules, and corrected the now-resolved VARIANT/GEOMETRY entries in
-  `Known Limitations` (these type-enum values now exist in the C API as of
-  DuckDB 1.5.3 / 1.5.x; `TypeId::Variant`/`Geometry` remain a tracked follow-up
-  pending a version-floor decision).
+  modules, and updated the VARIANT/GEOMETRY entries in `Known Limitations`,
+  `concepts/types.md`, and the `TypeId` reference to document the new
+  `duckdb-1-5-3` gate (previously tracked as a follow-up).
+- Added `// SAFETY:` comments to previously-undocumented `unsafe` blocks in the
+  `get_client_context` accessors (`scalar`, `copy_function`) and
+  `TableDescription::create`, and SPDX headers to `benches/interval_bench.rs` and
+  the test submodule files.
+- Corrected the README install note (it claimed v0.11.0 was the latest published
+  crate; v0.12.1 was in fact already on crates.io) and bumped install-example
+  version references throughout the README, book, and scaffold template to `0.13`.
 
 ## [0.12.1] — 2026-05-01
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -121,6 +121,26 @@ new to 1.5.3 specifically.
   crate; v0.12.1 was in fact already on crates.io) and bumped install-example
   version references throughout the README, book, and scaffold template to `0.13`.
 
+### CI
+
+- **docs.rs now builds with `duckdb-1-5-3`** (`[package.metadata.docs.rs]`), so
+  the feature-gated modules and new `TypeId` variants render on docs.rs and the
+  README's docs.rs links resolve (previously docs.rs built the empty default
+  feature set and omitted them).
+- **CI exercises the `duckdb-1-5-3` feature** — `check` / `test` / `clippy` for
+  `duckdb-1-5-3` alongside `duckdb-1-5`, with the `Clippy (beta)` and `doc` jobs
+  on `duckdb-1-5-3`.
+- **Fixed the `Nightly` CI job silently running stable** (the SHA-pinned
+  `dtolnay/rust-toolchain` step lacked `with: toolchain: nightly`).
+- **Mutation testing scoped to testable code** — DuckDB FFI-wrapper modules
+  whose methods require a live runtime (tests `bundled-test`-gated or absent) are
+  excluded from `cargo mutants`, since their mutants can't be killed by unit
+  tests. Extends the existing exclusion pattern to the 1.5.x wrappers
+  (`expression`, `file_system`, `appender`, `selection_vector`, `instance_cache`,
+  `table_description`, and the scalar/copy `*Info` accessors). Pure-logic code
+  (e.g. `DuckDbErrorType`, `TypeId` conversions) stays in scope; the mutants
+  feature set is bumped to `duckdb-1-5-3`.
+
 ## [0.12.1] — 2026-05-01
 
 ### Security

--- a/book/src/reference/known-limitations.md
+++ b/book/src/reference/known-limitations.md
@@ -76,15 +76,23 @@ All constructors have `_from_logical` variants for nested complex types.
 Introspection methods (`get_type_id`, `list_child_type`, `struct_child_count`,
 `decimal_width`, etc.) are also available.
 
-## VARIANT and GEOMETRY types (in the C API; `TypeId` pending)
+## VARIANT and GEOMETRY types (resolved — exposed behind `duckdb-1-5-3`)
 
 DuckDB v1.5.1 introduced the `VARIANT` type for Iceberg v3 support. As of
 **DuckDB 1.5.3** it is present in the C type enum as `DUCKDB_TYPE_VARIANT` (41),
 and the `GEOMETRY` type (`DUCKDB_TYPE_GEOMETRY`, 40) is present as well.
 
-quack-rs does **not yet** expose `TypeId::Variant` or `TypeId::Geometry`. This
-is a version-floor matter rather than a missing C API: the `duckdb-1-5` feature
-targets DuckDB **1.5.0**, but these enum values only exist in later 1.5.x
-bindings (`VARIANT` requires 1.5.3). Adding them under the current feature flag
-would break consumers pinned to libduckdb-sys 1.5.0–1.5.2, so it needs either a
-1.5.3 version floor or a finer-grained feature gate. Tracked as a follow-up.
+quack-rs exposes these as `TypeId::Variant` and `TypeId::Geometry`, gated behind
+the **`duckdb-1-5-3`** feature. That feature layers on top of `duckdb-1-5` and
+requires `libduckdb-sys >= 1.10503.1` (DuckDB 1.5.3). The separate gate exists
+because these type-enum values postdate the `duckdb-1-5` feature's 1.5.0 floor
+(`VARIANT` only landed in 1.5.3); keeping them out of `duckdb-1-5` preserves
+compatibility for consumers pinned to libduckdb-sys 1.5.0–1.5.2.
+
+```toml
+[dependencies]
+quack-rs = { version = "0.13", features = ["duckdb-1-5-3"] }
+```
+
+Neither type yet has dedicated `VectorReader`/`VectorWriter` helpers; access
+their data via the raw pointer from `duckdb_vector_get_data` when needed.

--- a/book/src/reference/type-id.md
+++ b/book/src/reference/type-id.md
@@ -49,13 +49,16 @@ from `libduckdb-sys` and provides safe, named variants.
 | `TypeId::SqlNull` | `SQLNULL` | `DUCKDB_TYPE_SQLNULL` | explicit SQL NULL type (`duckdb-1-5`) |
 | `TypeId::IntegerLiteral` | `INTEGER_LITERAL` | `DUCKDB_TYPE_INTEGER_LITERAL` | unresolved integer literal (`duckdb-1-5`) |
 | `TypeId::StringLiteral` | `STRING_LITERAL` | `DUCKDB_TYPE_STRING_LITERAL` | unresolved string literal (`duckdb-1-5`) |
+| `TypeId::Geometry` | `GEOMETRY` | `DUCKDB_TYPE_GEOMETRY` | spatial geometry value (`duckdb-1-5-3`) |
+| `TypeId::Variant` | `VARIANT` | `DUCKDB_TYPE_VARIANT` | self-describing nested value, e.g. Iceberg v3 (`duckdb-1-5-3`) |
 
-> **Not yet exposed:** `DUCKDB_TYPE_GEOMETRY` (40) and `DUCKDB_TYPE_VARIANT` (41)
-> exist in the DuckDB 1.5.x C type enum (`VARIANT` was added in DuckDB 1.5.3), but
-> `quack-rs` does not yet provide `TypeId::Geometry` / `TypeId::Variant`. These
-> constants postdate the `duckdb-1-5` feature's 1.5.0 floor, so exposing them
-> requires a version-gating decision (see
-> [Known Limitations](known-limitations.md)).
+> **Feature gate for `Geometry` / `Variant`:** `DUCKDB_TYPE_GEOMETRY` (40) and
+> `DUCKDB_TYPE_VARIANT` (41) require the **`duckdb-1-5-3`** feature, which layers
+> on top of `duckdb-1-5` and needs `libduckdb-sys >= 1.10503.1` (DuckDB 1.5.3).
+> They sit behind a separate feature because these type-enum values postdate the
+> `duckdb-1-5` feature's 1.5.0 floor (`VARIANT` was added in DuckDB 1.5.3); gating
+> them this way avoids breaking consumers pinned to libduckdb-sys 1.5.0–1.5.2.
+> See [Known Limitations](known-limitations.md).
 
 ---
 
@@ -73,8 +76,12 @@ let raw: libduckdb_sys::DUCKDB_TYPE = TypeId::BigInt.to_duckdb_type();
 
 ### `from_duckdb_type(raw) → TypeId`
 
-Converts a raw `DUCKDB_TYPE` constant back into a `TypeId`. Panics if the value
-does not match any known `DUCKDB_TYPE` constant.
+Converts a raw `DUCKDB_TYPE` constant back into a `TypeId`. Recognizes every
+variant available in the active feature set, including the `duckdb-1-5` values
+(`TIME_NS`, `ANY`, `VARINT`, `SQLNULL`, `INTEGER_LITERAL`, `STRING_LITERAL`) and
+the `duckdb-1-5-3` values (`GEOMETRY`, `VARIANT`) when those features are enabled.
+Panics if the value does not correspond to any variant available in the current
+feature configuration.
 
 ```rust
 use quack_rs::types::TypeId;
@@ -128,8 +135,9 @@ variants as follows:
 `HugeInt`, `Blob`, `List`, `Struct`, `Map`, `Uuid`, `Date`, `Time`, `Timestamp`,
 `TimestampTz`, `Decimal`, `TimestampS`, `TimestampMs`, `TimestampNs`, `Enum`,
 `Union`, `Bit`, `TimeTz`, `UHugeInt`, `Array`, `TimeNs`, `Any`, `Varint`, `SqlNull`,
-`IntegerLiteral`, `StringLiteral` do not yet have dedicated read/write helpers.
-Access these via the raw data pointer from `duckdb_vector_get_data`.
+`IntegerLiteral`, `StringLiteral`, `Geometry`, `Variant` do not yet have dedicated
+read/write helpers. Access these via the raw data pointer from
+`duckdb_vector_get_data`.
 
 ---
 

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -153,7 +153,7 @@ opening a connection (see [Pitfall P9](reference/pitfalls.md#p9)):
 ```toml
 # In your extension's Cargo.toml
 [dev-dependencies]
-quack-rs = { version = "0.7", features = ["bundled-test"] }
+quack-rs = { version = "0.13", features = ["bundled-test"] }
 ```
 
 > **Build time**: enabling `bundled-test` compiles a full copy of DuckDB from
@@ -511,7 +511,7 @@ harness properties.
 
 ```toml
 [dev-dependencies]
-quack-rs = { version = "0.7", features = [] }
+quack-rs = { version = "0.13", features = [] }
 proptest = "1"
 ```
 

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "cc",
  "libduckdb-sys",

--- a/mutants.toml
+++ b/mutants.toml
@@ -30,10 +30,12 @@ examine_globs = [
 ]
 
 # ── Features ─────────────────────────────────────────────────────────────────
-# Enable duckdb-1-5 so feature-gated code paths and their tests are included
-# in mutation testing.  Without this, mutants in #[cfg(feature = "duckdb-1-5")]
-# blocks are untestable (the tests that kill them are also feature-gated).
-features = ["duckdb-1-5"]
+# Enable duckdb-1-5-3 (implies duckdb-1-5) so feature-gated code paths and their
+# tests are included in mutation testing — including the duckdb-1-5-3 `TypeId`
+# variants (Geometry / Variant). Without this, mutants in
+# #[cfg(feature = "duckdb-1-5...")] blocks are untestable (the tests that kill
+# them are also feature-gated).
+features = ["duckdb-1-5-3"]
 
 # ── Exclusions ───────────────────────────────────────────────────────────────
 # Thin re-export modules and test-only code produce unproductive mutants.

--- a/mutants.toml
+++ b/mutants.toml
@@ -50,6 +50,19 @@ exclude_globs = [
     "src/testing/mock_vector.rs",  # test-only vector stub
     "src/testing/mod.rs",       # re-exports only
     "src/bin/**",               # binary entry points
+    # DuckDB 1.5.x FFI wrapper modules: every public method calls a DuckDB C
+    # function that panics in `cargo test` without a live runtime, so their
+    # mutants cannot be killed by unit tests (same rationale as the entries
+    # above). Their pure-logic siblings — e.g. `DuckDbErrorType` in error_data.rs
+    # and the `TypeId` conversions — are NOT excluded and stay mutation-tested.
+    "src/expression.rs",        # Expression: all methods call duckdb_expression_*
+    "src/file_system.rs",       # FileSystem/FileHandle: all methods call duckdb FS API
+    "src/appender.rs",          # Appender: all methods call duckdb_appender_*
+    "src/selection_vector.rs",  # SelectionVector: new() calls duckdb_create_selection_vector
+    "src/instance_cache.rs",    # InstanceCache: all methods call duckdb_*_instance_cache
+    "src/table_description.rs", # TableDescription: FFI methods; tests are bundled-test-gated
+    "src/scalar/info.rs",       # Scalar{Function,Bind,Init}Info: FFI accessor wrappers
+    "src/copy_function/info.rs",# Copy{Bind,GlobalInit,Sink,Finalize}Info: FFI accessor wrappers
 ]
 
 # Skip functions whose mutations are unproductive (Display/Debug impls,

--- a/src/aggregate/builder/tests.rs
+++ b/src/aggregate/builder/tests.rs
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
 use super::*;
 use crate::types::TypeId;
 use libduckdb_sys::{

--- a/src/copy_function/info.rs
+++ b/src/copy_function/info.rs
@@ -128,7 +128,9 @@ impl CopyBindInfo {
     ///
     /// The inner handle must be valid (requires `DuckDB` runtime).
     pub unsafe fn get_client_context(&self) -> crate::client_context::ClientContext {
+        // SAFETY: self.info is a valid copy-bind-info handle per this fn's contract.
         let ctx = unsafe { duckdb_copy_function_bind_get_client_context(self.info) };
+        // SAFETY: `ctx` is a client-context handle returned by DuckDB.
         unsafe { crate::client_context::ClientContext::from_raw(ctx) }
     }
 
@@ -243,7 +245,9 @@ impl CopyGlobalInitInfo {
     ///
     /// The inner handle must be valid (requires `DuckDB` runtime).
     pub unsafe fn get_client_context(&self) -> crate::client_context::ClientContext {
+        // SAFETY: self.info is a valid copy-global-init-info handle per this fn's contract.
         let ctx = unsafe { duckdb_copy_function_global_init_get_client_context(self.info) };
+        // SAFETY: `ctx` is a client-context handle returned by DuckDB.
         unsafe { crate::client_context::ClientContext::from_raw(ctx) }
     }
 
@@ -329,7 +333,9 @@ impl CopySinkInfo {
     ///
     /// The inner handle must be valid (requires `DuckDB` runtime).
     pub unsafe fn get_client_context(&self) -> crate::client_context::ClientContext {
+        // SAFETY: self.info is a valid copy-sink-info handle per this fn's contract.
         let ctx = unsafe { duckdb_copy_function_sink_get_client_context(self.info) };
+        // SAFETY: `ctx` is a client-context handle returned by DuckDB.
         unsafe { crate::client_context::ClientContext::from_raw(ctx) }
     }
 
@@ -415,7 +421,9 @@ impl CopyFinalizeInfo {
     ///
     /// The inner handle must be valid (requires `DuckDB` runtime).
     pub unsafe fn get_client_context(&self) -> crate::client_context::ClientContext {
+        // SAFETY: self.info is a valid copy-finalize-info handle per this fn's contract.
         let ctx = unsafe { duckdb_copy_function_finalize_get_client_context(self.info) };
+        // SAFETY: `ctx` is a client-context handle returned by DuckDB.
         unsafe { crate::client_context::ClientContext::from_raw(ctx) }
     }
 

--- a/src/error_data.rs
+++ b/src/error_data.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use std::ffi::{CStr, CString};
+use std::fmt;
 
 use libduckdb_sys::{
     duckdb_create_error_data, duckdb_destroy_error_data, duckdb_error_data,
@@ -245,12 +246,70 @@ impl DuckDbErrorType {
             _ => Self::Invalid,
         }
     }
+
+    /// Returns a short, human-readable label for this error category.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Invalid => "invalid",
+            Self::OutOfRange => "out of range",
+            Self::Conversion => "conversion",
+            Self::UnknownType => "unknown type",
+            Self::Decimal => "decimal",
+            Self::MismatchType => "type mismatch",
+            Self::DivideByZero => "divide by zero",
+            Self::ObjectSize => "object size",
+            Self::InvalidType => "invalid type",
+            Self::Serialization => "serialization",
+            Self::Transaction => "transaction",
+            Self::NotImplemented => "not implemented",
+            Self::Expression => "expression",
+            Self::Catalog => "catalog",
+            Self::Parser => "parser",
+            Self::Planner => "planner",
+            Self::Scheduler => "scheduler",
+            Self::Executor => "executor",
+            Self::Constraint => "constraint",
+            Self::Index => "index",
+            Self::Stat => "statistics",
+            Self::Connection => "connection",
+            Self::Syntax => "syntax",
+            Self::Settings => "settings",
+            Self::Binder => "binder",
+            Self::Network => "network",
+            Self::Optimizer => "optimizer",
+            Self::NullPointer => "null pointer",
+            Self::Io => "I/O",
+            Self::Interrupt => "interrupt",
+            Self::Fatal => "fatal",
+            Self::Internal => "internal",
+            Self::InvalidInput => "invalid input",
+            Self::OutOfMemory => "out of memory",
+            Self::Permission => "permission",
+            Self::ParameterNotResolved => "parameter not resolved",
+            Self::ParameterNotAllowed => "parameter not allowed",
+            Self::Dependency => "dependency",
+            Self::Http => "HTTP",
+            Self::MissingExtension => "missing extension",
+        }
+    }
+}
+
+impl fmt::Display for DuckDbErrorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// RAII wrapper for a `duckdb_error_data` handle.
 ///
 /// Automatically destroyed when dropped. Carries a structured error category
 /// ([`DuckDbErrorType`]) and a human-readable message.
+///
+/// Implements [`Display`][std::fmt::Display] and [`std::error::Error`], and
+/// converts into [`ExtensionError`] via [`From`] (or
+/// [`into_extension_error`][ErrorData::into_extension_error]) so it can be
+/// propagated with `?`.
 pub struct ErrorData {
     raw: duckdb_error_data,
 }
@@ -375,6 +434,33 @@ impl Drop for ErrorData {
     }
 }
 
+impl fmt::Debug for ErrorData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ErrorData")
+            .field("error_type", &self.error_type())
+            .field("message", &self.message())
+            .finish()
+    }
+}
+
+impl fmt::Display for ErrorData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.message() {
+            Some(msg) => write!(f, "{}: {msg}", self.error_type()),
+            None => f.write_str(self.error_type().as_str()),
+        }
+    }
+}
+
+impl std::error::Error for ErrorData {}
+
+impl From<ErrorData> for ExtensionError {
+    #[inline]
+    fn from(err: ErrorData) -> Self {
+        err.into_extension_error()
+    }
+}
+
 /// Checks whether `bytes` form a valid UTF-8 string according to `DuckDB`'s
 /// validator (`DuckDB` 1.5.0+).
 ///
@@ -489,5 +575,47 @@ mod tests {
         let err = unsafe { ErrorData::from_raw(std::ptr::null_mut()) };
         let raw = err.into_raw();
         assert!(raw.is_null());
+    }
+
+    #[test]
+    fn error_type_display_matches_as_str() {
+        for variant in ALL_VARIANTS {
+            assert!(!variant.as_str().is_empty(), "{variant:?} has empty label");
+            assert_eq!(format!("{variant}"), variant.as_str());
+        }
+    }
+
+    #[test]
+    fn error_type_labels_are_distinct() {
+        for (i, a) in ALL_VARIANTS.iter().enumerate() {
+            for b in ALL_VARIANTS.iter().skip(i + 1) {
+                assert_ne!(a.as_str(), b.as_str(), "{a:?} and {b:?} share a label");
+            }
+        }
+    }
+
+    #[test]
+    fn null_error_data_debug_and_display() {
+        // Null handle: error_type()/message() short-circuit without FFI calls,
+        // so Debug/Display are safe to exercise in a unit test.
+        let err = unsafe { ErrorData::from_raw(std::ptr::null_mut()) };
+        assert_eq!(err.to_string(), "invalid");
+        let dbg = format!("{err:?}");
+        assert!(dbg.contains("ErrorData"), "debug was: {dbg}");
+        assert!(dbg.contains("Invalid"), "debug was: {dbg}");
+    }
+
+    #[test]
+    fn from_error_data_for_extension_error() {
+        let err = unsafe { ErrorData::from_raw(std::ptr::null_mut()) };
+        let ext: ExtensionError = err.into();
+        assert_eq!(ext.as_str(), "unknown DuckDB error");
+    }
+
+    #[test]
+    fn error_data_usable_as_std_error() {
+        fn takes_error(_e: &dyn std::error::Error) {}
+        let err = unsafe { ErrorData::from_raw(std::ptr::null_mut()) };
+        takes_error(&err);
     }
 }

--- a/src/scaffold/templates.rs
+++ b/src/scaffold/templates.rs
@@ -31,7 +31,7 @@ crate-type = ["staticlib"]
 path = "src/wasm_lib.rs"
 
 [dependencies]
-quack-rs = {{ version = "0.11" }}
+quack-rs = {{ version = "0.13" }}
 libduckdb-sys = {{ version = ">=1.4.4, <2", features = ["loadable-extension"] }}
 
 [profile.release]

--- a/src/scaffold/tests.rs
+++ b/src/scaffold/tests.rs
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
 use super::*;
 
 fn valid_config() -> ScaffoldConfig {

--- a/src/scalar/builder/tests.rs
+++ b/src/scalar/builder/tests.rs
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
 use super::*;
 use crate::types::TypeId;
 use libduckdb_sys::{duckdb_data_chunk, duckdb_function_info, duckdb_vector};

--- a/src/scalar/info.rs
+++ b/src/scalar/info.rs
@@ -263,7 +263,10 @@ impl ScalarBindInfo {
     /// The inner handle must be valid (requires `DuckDB` runtime).
     pub unsafe fn get_client_context(&self) -> crate::client_context::ClientContext {
         let mut ctx: duckdb_client_context = core::ptr::null_mut();
+        // SAFETY: self.info is a valid bind-info handle per this fn's contract;
+        // the call writes the client-context handle into `ctx`.
         unsafe { duckdb_scalar_function_get_client_context(self.info, &raw mut ctx) };
+        // SAFETY: `ctx` was just populated by DuckDB with a client-context handle.
         unsafe { crate::client_context::ClientContext::from_raw(ctx) }
     }
 
@@ -369,7 +372,10 @@ impl ScalarInitInfo {
     /// The inner handle must be valid (requires `DuckDB` runtime).
     pub unsafe fn get_client_context(&self) -> crate::client_context::ClientContext {
         let mut ctx: duckdb_client_context = core::ptr::null_mut();
+        // SAFETY: self.info is a valid init-info handle per this fn's contract;
+        // the call writes the client-context handle into `ctx`.
         unsafe { duckdb_scalar_function_init_get_client_context(self.info, &raw mut ctx) };
+        // SAFETY: `ctx` was just populated by DuckDB with a client-context handle.
         unsafe { crate::client_context::ClientContext::from_raw(ctx) }
     }
 

--- a/src/table_description.rs
+++ b/src/table_description.rs
@@ -67,17 +67,25 @@ impl TableDescription {
         if rc != libduckdb_sys::DuckDBSuccess || desc.is_null() {
             // Try to get the error message.
             if !desc.is_null() {
+                // SAFETY: desc is non-null and was produced by
+                // duckdb_table_description_create above.
                 let err_ptr = unsafe { duckdb_table_description_error(desc) };
                 if !err_ptr.is_null() {
+                    // SAFETY: err_ptr is a valid null-terminated string owned by
+                    // the table description; it stays valid until we destroy it.
                     let msg = unsafe { CStr::from_ptr(err_ptr) }
                         .to_str()
                         .unwrap_or("unknown error");
                     let err = ExtensionError::new(format!(
                         "failed to describe table '{schema}.{table}': {msg}"
                     ));
+                    // SAFETY: desc is a non-null handle we own and have not yet
+                    // returned; destroying it also frees the error string.
                     unsafe { duckdb_table_description_destroy(&raw mut desc) };
                     return Err(err);
                 }
+                // SAFETY: desc is a non-null handle we own; destroy it before
+                // returning so it does not leak.
                 unsafe { duckdb_table_description_destroy(&raw mut desc) };
             }
             return Err(ExtensionError::new(format!(
@@ -132,13 +140,24 @@ impl TableDescription {
             Some(unsafe { LogicalType::from_raw(lt) })
         }
     }
+
+    /// Returns the raw `duckdb_table_description` handle without consuming the
+    /// wrapper. The wrapper retains ownership and destroys it on drop.
+    #[inline]
+    #[must_use]
+    pub const fn as_raw(&self) -> duckdb_table_description {
+        self.desc
+    }
 }
 
 impl Drop for TableDescription {
     fn drop(&mut self) {
-        // SAFETY: self.desc was obtained from duckdb_table_description_create.
-        unsafe {
-            duckdb_table_description_destroy(&raw mut self.desc);
+        if !self.desc.is_null() {
+            // SAFETY: self.desc is a non-null handle obtained from
+            // duckdb_table_description_create.
+            unsafe {
+                duckdb_table_description_destroy(&raw mut self.desc);
+            }
         }
     }
 }

--- a/src/testing/in_memory_db.rs
+++ b/src/testing/in_memory_db.rs
@@ -34,7 +34,7 @@
 //! ```toml
 //! # In your extension's Cargo.toml:
 //! [dev-dependencies]
-//! quack-rs = { version = "0.7", features = ["bundled-test"] }
+//! quack-rs = { version = "0.13", features = ["bundled-test"] }
 //! ```
 //!
 //! # Example

--- a/src/types/type_id.rs
+++ b/src/types/type_id.rs
@@ -31,6 +31,8 @@ use libduckdb_sys::{
     DUCKDB_TYPE_DUCKDB_TYPE_INTEGER_LITERAL, DUCKDB_TYPE_DUCKDB_TYPE_SQLNULL,
     DUCKDB_TYPE_DUCKDB_TYPE_STRING_LITERAL, DUCKDB_TYPE_DUCKDB_TYPE_TIME_NS,
 };
+#[cfg(feature = "duckdb-1-5-3")]
+use libduckdb_sys::{DUCKDB_TYPE_DUCKDB_TYPE_GEOMETRY, DUCKDB_TYPE_DUCKDB_TYPE_VARIANT};
 
 /// Identifies a `DuckDB` column type.
 ///
@@ -147,6 +149,18 @@ pub enum TypeId {
     /// concrete column type — used by `DuckDB`'s type resolution system.
     #[cfg(feature = "duckdb-1-5")]
     StringLiteral,
+    /// `GEOMETRY` — spatial geometry value (`DuckDB` 1.5.x; requires `duckdb-1-5-3`)
+    ///
+    /// Present in the C type enum as `DUCKDB_TYPE_GEOMETRY` (40). Gated behind
+    /// the `duckdb-1-5-3` feature; see that feature's documentation for the
+    /// version-floor rationale.
+    #[cfg(feature = "duckdb-1-5-3")]
+    Geometry,
+    /// `VARIANT` — self-describing nested value, e.g. for Iceberg v3 (`DuckDB` 1.5.3; requires `duckdb-1-5-3`)
+    ///
+    /// Added to the C type enum as `DUCKDB_TYPE_VARIANT` (41) in `DuckDB` 1.5.3.
+    #[cfg(feature = "duckdb-1-5-3")]
+    Variant,
 }
 
 impl TypeId {
@@ -210,14 +224,25 @@ impl TypeId {
             Self::IntegerLiteral => DUCKDB_TYPE_DUCKDB_TYPE_INTEGER_LITERAL,
             #[cfg(feature = "duckdb-1-5")]
             Self::StringLiteral => DUCKDB_TYPE_DUCKDB_TYPE_STRING_LITERAL,
+            #[cfg(feature = "duckdb-1-5-3")]
+            Self::Geometry => DUCKDB_TYPE_DUCKDB_TYPE_GEOMETRY,
+            #[cfg(feature = "duckdb-1-5-3")]
+            Self::Variant => DUCKDB_TYPE_DUCKDB_TYPE_VARIANT,
         }
     }
 
     /// Converts a raw `DUCKDB_TYPE` constant back into a [`TypeId`].
     ///
+    /// Recognizes every variant available in the active feature set, including
+    /// the `duckdb-1-5` type-enum values (`TIME_NS`, `ANY`, `BIGNUM`/`VARINT`,
+    /// `SQLNULL`, `INTEGER_LITERAL`, `STRING_LITERAL`) and the `duckdb-1-5-3`
+    /// values (`GEOMETRY`, `VARIANT`) when those features are enabled.
+    ///
     /// # Panics
     ///
-    /// Panics if the value does not match any known `DUCKDB_TYPE` constant.
+    /// Panics if `raw` does not correspond to any `TypeId` variant available in
+    /// the current feature configuration — for example, a 1.5.x type value when
+    /// the `duckdb-1-5` feature is disabled, or a future/unknown type value.
     #[must_use]
     pub const fn from_duckdb_type(raw: DUCKDB_TYPE) -> Self {
         // Using if-else chain because match on non-primitive constants is not
@@ -289,6 +314,39 @@ impl TypeId {
         } else if raw == DUCKDB_TYPE_DUCKDB_TYPE_ARRAY {
             Self::Array
         } else {
+            // DuckDB 1.5.0+ type-enum values (feature-gated). Kept in a nested
+            // block because `#[cfg]` cannot be attached to an `else if` arm.
+            #[cfg(feature = "duckdb-1-5")]
+            {
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_TIME_NS {
+                    return Self::TimeNs;
+                }
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_ANY {
+                    return Self::Any;
+                }
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_BIGNUM {
+                    return Self::Varint;
+                }
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_SQLNULL {
+                    return Self::SqlNull;
+                }
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_INTEGER_LITERAL {
+                    return Self::IntegerLiteral;
+                }
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_STRING_LITERAL {
+                    return Self::StringLiteral;
+                }
+            }
+            // DuckDB 1.5.3+ type-enum values (feature-gated).
+            #[cfg(feature = "duckdb-1-5-3")]
+            {
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_GEOMETRY {
+                    return Self::Geometry;
+                }
+                if raw == DUCKDB_TYPE_DUCKDB_TYPE_VARIANT {
+                    return Self::Variant;
+                }
+            }
             panic!("unknown DUCKDB_TYPE value")
         }
     }
@@ -351,6 +409,10 @@ impl TypeId {
             Self::IntegerLiteral => "INTEGER_LITERAL",
             #[cfg(feature = "duckdb-1-5")]
             Self::StringLiteral => "STRING_LITERAL",
+            #[cfg(feature = "duckdb-1-5-3")]
+            Self::Geometry => "GEOMETRY",
+            #[cfg(feature = "duckdb-1-5-3")]
+            Self::Variant => "VARIANT",
         }
     }
 }
@@ -413,6 +475,10 @@ mod tests {
             TypeId::IntegerLiteral,
             #[cfg(feature = "duckdb-1-5")]
             TypeId::StringLiteral,
+            #[cfg(feature = "duckdb-1-5-3")]
+            TypeId::Geometry,
+            #[cfg(feature = "duckdb-1-5-3")]
+            TypeId::Variant,
         ];
         for t in types {
             // sql_name should not be empty and should match Display
@@ -599,11 +665,56 @@ mod tests {
             TypeId::TimeTz,
             TypeId::UHugeInt,
             TypeId::Array,
+            // DuckDB 1.5.0+ variants: from_duckdb_type must handle these too
+            // (previously it panicked on them — see the panic-gap fix).
+            #[cfg(feature = "duckdb-1-5")]
+            TypeId::TimeNs,
+            #[cfg(feature = "duckdb-1-5")]
+            TypeId::Any,
+            #[cfg(feature = "duckdb-1-5")]
+            TypeId::Varint,
+            #[cfg(feature = "duckdb-1-5")]
+            TypeId::SqlNull,
+            #[cfg(feature = "duckdb-1-5")]
+            TypeId::IntegerLiteral,
+            #[cfg(feature = "duckdb-1-5")]
+            TypeId::StringLiteral,
+            #[cfg(feature = "duckdb-1-5-3")]
+            TypeId::Geometry,
+            #[cfg(feature = "duckdb-1-5-3")]
+            TypeId::Variant,
         ];
         for &tid in &variants {
             let raw = tid.to_duckdb_type();
             let back = TypeId::from_duckdb_type(raw);
             assert_eq!(back, tid, "roundtrip failed for {tid:?}");
         }
+    }
+
+    #[cfg(feature = "duckdb-1-5-3")]
+    #[test]
+    fn geometry_maps_to_correct_duckdb_type() {
+        assert_eq!(
+            TypeId::Geometry.to_duckdb_type(),
+            DUCKDB_TYPE_DUCKDB_TYPE_GEOMETRY
+        );
+    }
+
+    #[cfg(feature = "duckdb-1-5-3")]
+    #[test]
+    fn variant_maps_to_correct_duckdb_type() {
+        assert_eq!(
+            TypeId::Variant.to_duckdb_type(),
+            DUCKDB_TYPE_DUCKDB_TYPE_VARIANT
+        );
+    }
+
+    #[cfg(feature = "duckdb-1-5-3")]
+    #[test]
+    fn geometry_variant_sql_names_and_display() {
+        assert_eq!(TypeId::Geometry.sql_name(), "GEOMETRY");
+        assert_eq!(TypeId::Variant.sql_name(), "VARIANT");
+        assert_eq!(format!("{}", TypeId::Geometry), "GEOMETRY");
+        assert_eq!(format!("{}", TypeId::Variant), "VARIANT");
     }
 }

--- a/src/validate/description_yml/tests.rs
+++ b/src/validate/description_yml/tests.rs
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
 use super::parser::parse_kv;
 use super::*;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -544,7 +544,7 @@ fn scaffold_generated_code_compiles() {
     let tmp = tmp.path().to_path_buf();
     fs::create_dir_all(tmp.join("src")).unwrap();
 
-    // The scaffold Cargo.toml references `quack-rs = "0.11"` from crates.io.
+    // The scaffold Cargo.toml references `quack-rs = "0.13"` from crates.io.
     // Replace it with a path dependency pointing to this workspace root so
     // `cargo check` uses the local (possibly-modified) crate.
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -558,7 +558,7 @@ fn scaffold_generated_code_compiles() {
         if f.path == "Cargo.toml" {
             // Rewrite quack-rs dep to use local path
             let patched = f.content.replace(
-                r#"quack-rs = { version = "0.11" }"#,
+                r#"quack-rs = { version = "0.13" }"#,
                 &format!(
                     "quack-rs = {{ path = \"{}\" }}",
                     workspace_root.display().to_string().replace('\\', "/")


### PR DESCRIPTION
## Summary

Prepares the **v0.13.0** release on top of #91, lands `TypeId::Variant` / `TypeId::Geometry`, polishes the new 1.5.x API, and folds in an engineering-excellence sweep. **No tag / publish / GitHub release has been created — that's left for the maintainer.**

### Version reconciliation (verified from primary sources)
- `cargo search quack-rs` → **`0.12.1` is the latest *published* crate** (not `0.11.0`); `git ls-remote --tags` confirms tags through `v0.12.1`.
- The README's note claiming v0.11.0 was the latest published (and v0.12.1 "unpublished") was **stale and wrong** — corrected here.
- Additive, feature-gated public API ⇒ minor bump to **0.13.0** (confirmed with maintainer).

### Task 2 — `TypeId::Variant` / `TypeId::Geometry` (new `duckdb-1-5-3` feature)
- New **`duckdb-1-5-3`** feature (implies `duckdb-1-5`) gates `DUCKDB_TYPE_VARIANT` (41, added in DuckDB 1.5.3) and `DUCKDB_TYPE_GEOMETRY` (40) — verified present in `libduckdb-sys 1.10503.1` bindgen. A **separate** gate preserves compatibility for consumers pinned to libduckdb-sys 1.5.0–1.5.2 (chosen over raising the crate-wide floor, which would drop 1.4.x/early-1.5.x support). Full `to_duckdb_type` / `from_duckdb_type` / `sql_name` / `Display` coverage + tests.
- **Latent FFI-panic fix:** `TypeId::from_duckdb_type` recognised only base (1.4) values and `panic!`ed on the `duckdb-1-5` values (`TIME_NS`/`ANY`/`VARINT`/`SQLNULL`/`INTEGER_LITERAL`/`STRING_LITERAL`) — reachable via the public `LogicalType::get_type_id()` in bind callbacks (Pitfall L3). Now maps every variant in the active feature set.

### API polish (`error_data`)
- `ErrorData`: `Debug` + `Display` + `std::error::Error`, and `From<ErrorData> for ExtensionError` (alongside `into_extension_error`) so it propagates with `?`.
- `DuckDbErrorType`: `Display` (+ `pub const fn as_str`).
- `TableDescription`: `as_raw()` accessor + null-checked `Drop` (matching peer wrappers).

### Engineering hygiene
- `// SAFETY:` comments on the previously-undocumented `get_client_context` unsafe blocks (`scalar`, `copy_function`) and `TableDescription::create`; SPDX headers on the benchmark and test submodule files.
- **CI:** fixed the `Nightly` job silently running stable (missing `with: toolchain: nightly` — same class as the old MSRV bug); `duckdb-1-5-3` now covered by the feature job + `Clippy (beta)` + `doc`.
- **docs.rs** now builds the full feature-gated API (`[package.metadata.docs.rs]`), so the README's docs.rs module links resolve (previously docs.rs built the empty default feature set).
- **Mutation testing** scoped to testable code — DuckDB FFI-wrapper modules (tests `bundled-test`-gated/absent) excluded from `cargo mutants`; feature set bumped to `duckdb-1-5-3`.

### Release prep
- `Cargo.toml` `0.12.1` → `0.13.0`; `[Unreleased]` → `[0.13.0]` in `CHANGELOG.md` + book changelog (kept in sync); comparison-link footer; `SECURITY.md` table; install-example refs → `0.13` across README/book/scaffold.

## Verification (local)
Full gate matrix green on **stable 1.94.1**, **MSRV 1.87.0**, and **beta**:
- `cargo fmt --check`; `cargo clippy --all-targets` for default / `duckdb-1-5` / `duckdb-1-5-3` (`-D warnings`)
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --features duckdb-1-5-3`
- `cargo test --all-targets` (default + `duckdb-1-5-3`), `cargo +1.87.0 check` (default + `duckdb-1-5-3`), `cargo bench --no-run`
- `examples/hello-ext`: check / clippy / test (lockfile re-synced to `0.13.0`)
- `cargo deny check` (clean — no advisories); `cargo publish --dry-run` (clean); `mdbook build` (clean)

## Notes / out of scope
- **Did not** wrap `duckdb_geometry_type_get_crs` (optional; deferred — uncertain string-ownership semantics, and GEOMETRY support is currently just the `TypeId`).
- **Did not** touch the open #90 or the `duckdb`/`bundled` dev-dependency. FYI: that unconditional bundled dev-dep is the root cause of the ~45-min `cargo mutants` CI time (every build compiles DuckDB from source, ~19 min, and mutants' scratch dirs bypass the cache) — #90's dev-dep change is the real fix.

## Test plan
- [ ] CI green on this branch (incl. the new `duckdb-1-5-3` jobs, MSRV, beta clippy, deny, publish-dry-run)
- [ ] Confirm docs.rs renders the 1.5.x modules + `Variant`/`Geometry` once published
- [ ] **Maintainer:** review version `0.13.0`, then run the gated release steps (tag → GitHub release → `cargo publish`) per `RELEASING.md`

https://claude.ai/code/session_01NptHRPwcHHRdxQuN1Cog6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01NptHRPwcHHRdxQuN1Cog6C)_