### PR TITLE
feat: support wasm32-unknown-emscripten target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,9 +120,11 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 
-// DuckDB's C API and duckdb_string_t layout assume 64-bit pointers.
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("quack-rs requires a 64-bit target (DuckDB does not support 32-bit platforms).");
+// quack-rs supports 64-bit targets and `wasm32-unknown-emscripten` (the
+// DuckDB-WASM target). The `duckdb_string_t` layout reserves 8 bytes for the
+// heap pointer regardless of pointer width — see `vector::string` for details.
+#[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
+compile_error!("quack-rs supports 64-bit targets and wasm32-unknown-emscripten.");
 
 pub mod aggregate;
 pub mod callback;

--- a/src/vector/string.rs
+++ b/src/vector/string.rs
@@ -102,9 +102,11 @@ impl<'a> DuckStringView<'a> {
     ///
     /// # Platform assumption
     ///
-    /// The pointer-format branch reads bytes 8–15 as a `usize` pointer, which
-    /// assumes a 64-bit platform (8-byte pointers). `DuckDB` itself only supports
-    /// 64-bit platforms, so this is a safe assumption.
+    /// The pointer-format branch reads bytes 8–15 as a `u64` and truncates to
+    /// `usize`. On 64-bit targets this is a lossless round-trip; on 32-bit
+    /// (DuckDB-WASM via `wasm32-unknown-emscripten`) the C union still reserves
+    /// 8 bytes for the pointer slot but only the lower 4 carry the address —
+    /// the upper 4 are padding/zero. `u64 as usize` returns those lower bytes.
     ///
     /// # Safety (internal)
     ///
@@ -116,11 +118,13 @@ impl<'a> DuckStringView<'a> {
             // Inline case: data starts at byte 4, length bytes follow
             Some(&self.bytes[4..4 + self.length])
         } else {
-            // Pointer case: bytes 8–15 contain the pointer (little-endian usize)
+            // Pointer case: bytes 8–15 hold the heap pointer in an 8-byte slot.
             // SAFETY: For pointer-format strings, bytes 8..16 hold a valid pointer
             // to heap memory allocated by DuckDB and valid for the vector's lifetime.
             let ptr_bytes: [u8; 8] = self.bytes[8..16].try_into().ok()?;
-            let ptr_val = usize::from_le_bytes(ptr_bytes) as *const u8;
+            // Read as u64 so this works regardless of `usize` width; truncating
+            // to `usize` is a no-op on 64-bit and yields the low 4 bytes on wasm32.
+            let ptr_val = u64::from_le_bytes(ptr_bytes) as usize as *const u8;
             if ptr_val.is_null() {
                 return None;
             }


### PR DESCRIPTION
The build was hard-rejected for any non-64-bit target by a top-level `compile_error!` in lib.rs, and `vector::string::as_bytes_unsafe` parsed the pointer slot as a `usize` — assuming 8-byte pointers and erroring out on wasm32.

DuckDB's 16-byte `duckdb_string_t` reserves bytes 8..16 for the heap pointer slot regardless of platform pointer width. On wasm32 only the low 4 bytes carry the address; the upper 4 are padding/zero. Reading the slot as a `u64` then casting to `usize` is a no-op on 64-bit and correctly yields the low 4 bytes on wasm32 little-endian.

<!-- SPDX-License-Identifier: MIT -->

## Summary

<!-- What does this PR change and why? One paragraph is enough. -->

## Type of change

- [x] Bug fix (non-breaking, fixes a specific issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [ ] Documentation update
- [ ] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Checklist

### Code quality
- [ ] `cargo test --all-targets` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo fmt` applied (no diff)
- [ ] `cargo doc --no-deps` builds without warnings
- [ ] All `unsafe` blocks have a `// SAFETY:` comment
- [ ] SPDX header on every new file
- [ ] No file exceeds 500 lines

### Testing
- [ ] New code has tests
- [ ] `cargo mutants --file <changed-files>` shows zero surviving mutants

### Documentation
- [ ] Public API changes are documented in rustdoc
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (for user-facing changes)
- [ ] Book (`book/src/`) updated if the change affects extension authors
- [ ] New FFI pitfall discovered → added to `LESSONS.md` and `book/src/reference/pitfalls.md`

### Safety (for changes touching `unsafe`)
- [ ] No new panics introduced in FFI callback paths
- [ ] No new paths that could cross the FFI boundary with an unwinding panic
- [ ] `#![deny(unsafe_op_in_unsafe_fn)]` remains satisfied
