### PR TITLE
Release v0.14.0 — wasm32 + prebuilt-libduckdb test path, tar security fix, OSV/GHSA CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
+  # Harden against transient crates.io/CDN download flakes — notably
+  # "[16] Error in the HTTP2 framing layer" when fetching the duckdb+arrow tree.
+  # Retry network ops and force HTTP/1.1 (disabling HTTP/2 multiplexing sidesteps
+  # the HTTP/2 framing errors). Child cargo invocations inherit these too.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@
 #
 # Continuous integration — enforces all quality gates.
 #
-# Jobs: check, test (default + bundled + duckdb-1-5), clippy, clippy-beta,
-#       fmt, doc, msrv, bench-compile, example-check, scaffold-compile,
-#       symbol-check, extension-load, publish-dry-run, security, nightly.
+# Jobs: check, test (default + bundled + bundled-prebuilt + duckdb-1-5), wasm,
+#       clippy, clippy-beta, fmt, doc, msrv, bench-compile, example-check,
+#       scaffold-compile, symbol-check, extension-load, publish-dry-run,
+#       security, nightly.
 
 name: CI
 
@@ -64,6 +65,35 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-targets --features bundled-test
 
+  # Exercises the `bundled-test-prebuilt` path: link a pre-built libduckdb
+  # instead of compiling DuckDB from C++ source. Combined with duckdb-1-5-3 this
+  # is also the only job that runs the DuckDB 1.5.x FFI wrapper tests (appender,
+  # selection_vector, instance_cache, ...) against a real DuckDB runtime.
+  # Linux only — the pre-built release archive is published per-platform.
+  test-bundled-prebuilt:
+    name: Test bundled-test-prebuilt (prebuilt libduckdb)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Download pre-built libduckdb
+        # Keep the version in sync with the `duckdb` / `libduckdb-sys` dependency
+        # (1.10503.x == DuckDB v1.5.3). The release zip ships libduckdb.so and
+        # duckdb.hpp; the C++ shim is compiled against the latter.
+        run: |
+          curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.5.3/libduckdb-linux-amd64.zip -o "${{ runner.temp }}/libduckdb.zip"
+          mkdir -p "${{ runner.temp }}/libduckdb"
+          unzip -o "${{ runner.temp }}/libduckdb.zip" -d "${{ runner.temp }}/libduckdb"
+      - name: Test against pre-built libduckdb
+        env:
+          # DUCKDB_LIB_DIR resolves headers + link search; LD_LIBRARY_PATH lets the
+          # test binary find libduckdb.so at run time (the link-time rpath emitted
+          # by libduckdb-sys does not propagate to this downstream test binary).
+          DUCKDB_LIB_DIR: ${{ runner.temp }}/libduckdb
+          LD_LIBRARY_PATH: ${{ runner.temp }}/libduckdb
+        run: cargo test --all-targets --features bundled-test-prebuilt,duckdb-1-5-3
+
   test-duckdb-1-5:
     name: Test duckdb-1-5 / duckdb-1-5-3 features
     runs-on: ubuntu-latest
@@ -77,6 +107,22 @@ jobs:
       - run: cargo check --all-targets --features duckdb-1-5-3
       - run: cargo test --all-targets --features duckdb-1-5-3
       - run: cargo clippy --all-targets --features duckdb-1-5-3 -- -D warnings
+
+  wasm:
+    name: WASM (wasm32-unknown-emscripten)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: wasm32-unknown-emscripten
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # DuckDB-WASM target. quack-rs's own lib must compile for wasm32; in
+      # loadable-extension mode libduckdb-sys is headers-only, so `cargo check`
+      # needs no emscripten toolchain. `--all-targets` is intentionally avoided —
+      # it would pull the bundled-DuckDB test path, which requires em++.
+      - run: cargo check --lib --target wasm32-unknown-emscripten
+      - run: cargo check --lib --features duckdb-1-5-3 --target wasm32-unknown-emscripten
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 # Jobs: check, test (default + bundled + bundled-prebuilt + duckdb-1-5), wasm,
 #       clippy, clippy-beta, fmt, doc, msrv, bench-compile, example-check,
 #       scaffold-compile, symbol-check, extension-load, publish-dry-run,
-#       security, nightly.
+#       security, osv-scan, nightly.
 
 name: CI
 
@@ -309,6 +309,27 @@ jobs:
         run: cargo install cargo-deny --locked --version "0.19.0"
       - name: Run cargo-deny check
         run: cargo deny check
+
+  # OSV / GHSA advisory scan. The cargo-deny job above consults only the RustSec
+  # advisory database; OSV.dev aggregates GHSA *and* RustSec, so GHSA-only
+  # advisories that RustSec has not mirrored (e.g. GHSA-3pv8-6f4r-ffg2 in `tar`)
+  # are caught here. Scans both lockfiles — `tar` reaches the example via the
+  # `libduckdb-sys` build-dependency. The binary is version- and checksum-pinned.
+  osv-scan:
+    name: Security (OSV / GHSA)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install osv-scanner (pinned, checksum-verified)
+        run: |
+          VER=2.3.8
+          SHA=bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc
+          curl -fsSL -o osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/v${VER}/osv-scanner_linux_amd64"
+          echo "${SHA}  osv-scanner" | sha256sum -c -
+          chmod +x osv-scanner
+      - name: Scan lockfiles (root + example) against OSV
+        run: ./osv-scanner --lockfile=Cargo.lock --lockfile=examples/hello-ext/Cargo.lock
 
   nightly:
     name: Nightly (informational)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
+  # Harden against transient crates.io/CDN download flakes — notably
+  # "[16] Error in the HTTP2 framing layer" when fetching the duckdb+arrow tree.
+  # Retry network ops and force HTTP/1.1 (disabling HTTP/2 multiplexing sidesteps
+  # the HTTP/2 framing errors). Child cargo invocations inherit these too.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
 
 # ── Job 1: Validate tag & extract metadata ────────────────────────────────────
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `bundled-test` can now link against a pre-built libduckdb instead of
+  compiling DuckDB from C++ source. Opt in with
+  `default-features = false, features = ["bundled-test"]` plus either
+  `DUCKDB_DOWNLOAD_LIB=1` (libduckdb-sys downloads the upstream release
+  zip) or `DUCKDB_LIB_DIR=...` (use a libduckdb tree you already have).
+  Default behaviour is unchanged.
+- `InMemoryDb::open_unsigned()` opens an in-memory database with
+  `allow_unsigned_extensions=true`, allowing downstream extension crates
+  to `LOAD` their own locally-built (unsigned) `.duckdb_extension`
+  artifact for integration testing.
+
 ## [0.13.0] - 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-07
+
 ### Added
 
 - **`wasm32-unknown-emscripten` support** (the DuckDB-WASM target). The crate no
@@ -34,11 +36,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   downstream consumer's `Cargo.lock` — no longer pulls the DuckDB + arrow tree,
   and the default test build no longer compiles DuckDB.
 
-### Security / maintenance
+### Security
 
-- Bumped `cc` 1.2.62 → 1.2.63 (which moves `shlex` 1.3.0 → 2.0.1) and `tar`
-  0.4.45 → 0.4.46 across both lockfiles; refreshed the `codecov/codecov-action`
-  pin to v6.0.1.
+- **`tar` 0.4.45 → 0.4.46** in both the root and example lockfiles, resolving
+  **GHSA-3pv8-6f4r-ffg2** ("PAX header desynchronization", Moderate). `tar` is a
+  `libduckdb-sys` build-dependency, so it appears in both `Cargo.lock` files and
+  raised one Dependabot alert each — the two moderate alerts reported on `main`.
+  This advisory is published in the GitHub Advisory Database (GHSA) but not the
+  RustSec database, so `cargo deny` did not flag it; the new OSV scan below closes
+  that gap.
+- Bumped `cc` 1.2.62 → 1.2.63 (which moves `shlex` 1.3.0 → 2.0.1) and refreshed
+  the `codecov/codecov-action` pin to v6.0.1.
+
+### CI / tooling
+
+- Added an **OSV / GHSA advisory scan** to CI (`osv-scanner`, pinned to v2.3.8 via
+  a checksum-verified binary) covering both `Cargo.lock` files. `cargo deny`
+  consults only the RustSec database; OSV.dev aggregates GHSA **and** RustSec, so
+  GHSA-only advisories (such as the `tar` one above) now fail CI alongside the
+  existing cargo-deny gate.
 
 ## [0.13.0] - 2026-05-24
 
@@ -1087,7 +1103,8 @@ the workspace `Cargo.lock` and `examples/hello-ext/Cargo.lock`.
 - CI pipeline: check, test, clippy, fmt, doc, MSRV, bench-compile
 - `SECURITY.md` vulnerability disclosure policy
 
-[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/tomtom215/quack-rs/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/tomtom215/quack-rs/compare/v0.11.0...v0.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `bundled-test` can now link against a pre-built libduckdb instead of
-  compiling DuckDB from C++ source. Opt in with
-  `default-features = false, features = ["bundled-test"]` plus either
-  `DUCKDB_DOWNLOAD_LIB=1` (libduckdb-sys downloads the upstream release
-  zip) or `DUCKDB_LIB_DIR=...` (use a libduckdb tree you already have).
-  Default behaviour is unchanged.
+- **`wasm32-unknown-emscripten` support** (the DuckDB-WASM target). The crate no
+  longer hard-rejects non-64-bit targets with a top-level `compile_error!`, and
+  the `duckdb_string_t` pointer slot is read as a `u64` then narrowed to `usize`
+  — lossless on 64-bit, and on wasm32 it yields the low 4 bytes of the 8-byte
+  slot (the upper 4 are zero padding in DuckDB's 16-byte layout). The full public
+  API, including the `duckdb-1-5-3` surface, `cargo check`s for
+  `wasm32-unknown-emscripten`; CI now guards this. (Thanks @killzoner.)
+- **`bundled-test-prebuilt` feature** — links a *pre-built* libduckdb instead of
+  compiling DuckDB from C++ source, for a much faster test build. Supply the
+  library via `DUCKDB_DOWNLOAD_LIB=1` (`libduckdb-sys` downloads the upstream
+  release zip) or `DUCKDB_LIB_DIR=...` (a libduckdb tree you already have).
+  `bundled-test` continues to compile DuckDB from source. (Thanks @killzoner.)
 - `InMemoryDb::open_unsigned()` opens an in-memory database with
-  `allow_unsigned_extensions=true`, allowing downstream extension crates
-  to `LOAD` their own locally-built (unsigned) `.duckdb_extension`
-  artifact for integration testing.
+  `allow_unsigned_extensions=true`, allowing downstream extension crates to
+  `LOAD` their own locally-built (unsigned) `.duckdb_extension` artifact for
+  integration testing. (Thanks @killzoner.)
+
+### Changed
+
+- `duckdb` is now a purely optional dependency, activated only by `bundled-test`
+  / `bundled-test-prebuilt`. It is no longer a dev-dependency, and there is no
+  default `bundled` feature. As a result, a plain `cargo test` — and every
+  downstream consumer's `Cargo.lock` — no longer pulls the DuckDB + arrow tree,
+  and the default test build no longer compiles DuckDB.
+
+### Security / maintenance
+
+- Bumped `cc` 1.2.62 → 1.2.63 (which moves `shlex` 1.3.0 → 2.0.1) and `tar`
+  0.4.45 → 0.4.46 across both lockfiles; refreshed the `codecov/codecov-action`
+  pin to v6.0.1.
 
 ## [0.13.0] - 2026-05-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "cc",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -654,7 +654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1910,7 +1910,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -2085,7 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2171,9 +2171,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2190,7 +2190,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2604,7 +2604,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,46 @@ name = "quack_rs"
 crate-type = ["rlib"]
 
 [features]
+default = ["bundled"]
+
+## Compiles a bundled copy of DuckDB from C++ source via the `duckdb` crate's
+## `bundled` feature. Required for the default `bundled-test` path. Disable to
+## link against a pre-built libduckdb (see `bundled-test` docs for the env vars).
+bundled = ["duckdb?/bundled"]
+## Enables the `testing::InMemoryDb` helper which opens a real in-memory
+## DuckDB database for integration testing.
+##
+## Two modes:
+## 1. With `bundled` (default): libduckdb is compiled from source by the
+##    `duckdb` crate. No env vars required; cold builds take ~5-10 min.
+## 2. Without `bundled` (`default-features = false, features = ["bundled-test"]`):
+##    quack-rs links against a pre-built libduckdb. Set one of:
+##    - `DUCKDB_DOWNLOAD_LIB=1` — libduckdb-sys downloads the prebuilt zip
+##      from the upstream DuckDB release (~30 MB, cached under `target/`).
+##      Recommended.
+##    - `DUCKDB_LIB_DIR=/path/to/libduckdb` — link against a libduckdb tree
+##      you already have (also set `DUCKDB_INCLUDE_DIR` if `duckdb.hpp` isn't
+##      sitting alongside the library).
+##
+## Enabling this feature also initialises the `loadable-extension` dispatch
+## table from the linked DuckDB symbols, so `InMemoryDb::open()` works in
+## `cargo test` even though no DuckDB host process loads the extension.
+##
+## # Important: architectural limitation
+##
+## Even with this feature, quack-rs's own wrappers (`VectorReader`, `VectorWriter`,
+## `Connection::register_*`) still route through the `loadable-extension` dispatch
+## table and cannot be called in `cargo test`. Use `InMemoryDb` for SQL-level
+## assertions (e.g. verifying SQL macro output) and `MockVectorWriter` /
+## `MockVectorReader` for callback logic tests.
+##
+## # Usage in your extension
+##
+## ```toml
+## [dev-dependencies]
+## quack-rs = { version = "0.11", features = ["bundled-test"] }
+## ```
+bundled-test = ["dep:duckdb"]
 ## Enables wrappers for DuckDB 1.5.0 C API additions (e.g. scalar function local
 ## states, config option registration). Requires `libduckdb-sys >= 1.5.0` to be
 ## resolved by Cargo. Has no effect when compiled against libduckdb-sys 1.4.x.
@@ -76,35 +116,9 @@ duckdb-1-5 = []
 ##   type-enum values behind a single, verifiable version requirement.
 duckdb-1-5-3 = ["duckdb-1-5"]
 
-## Links a bundled copy of DuckDB for integration testing.
-##
-## When this feature is enabled, the `testing::InMemoryDb` helper becomes available.
-## It opens a real in-memory DuckDB database using the `duckdb` Rust crate.
-##
-## Enabling this feature also initialises the `loadable-extension` dispatch table
-## (the function-pointer table that normally gets populated at extension-load time)
-## from the bundled DuckDB symbols, so that `InMemoryDb::open()` works correctly
-## even in `cargo test` where no DuckDB host process loads the extension.
-##
-## # Important: architectural limitation
-##
-## Even with this feature, quack-rs's own wrappers (`VectorReader`, `VectorWriter`,
-## `Connection::register_*`) still route through the `loadable-extension` dispatch
-## table and cannot be called in `cargo test`. Use `InMemoryDb` for SQL-level
-## assertions (e.g. verifying SQL macro output) and `MockVectorWriter` /
-## `MockVectorReader` for callback logic tests.
-##
-## # Usage in your extension
-##
-## ```toml
-## [dev-dependencies]
-## quack-rs = { version = "0.13", features = ["bundled-test"] }
-## ```
-bundled-test = ["dep:duckdb"]
-
 [dependencies]
 libduckdb-sys = { version = ">=1.4.4, <2", features = ["loadable-extension"] }
-duckdb = { version = ">=1.4.4, <2", features = ["bundled"], optional = true }
+duckdb = { version = ">=1.4.4, <2", optional = true }
 mutants = "0.0.4"
 
 [build-dependencies]
@@ -114,7 +128,7 @@ mutants = "0.0.4"
 cc = "1"
 
 [dev-dependencies]
-duckdb = { version = ">=1.4.4, <2", features = ["bundled"] }
+duckdb = { version = ">=1.4.4, <2" }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 # tempfile is version-pinned for reproducible dev builds. It was originally held
@@ -148,6 +162,9 @@ module_name_repetitions = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 return_self_not_must_use = "allow"
+# Transitive duplicates from arrow/ahash/ring trees — not under our control,
+# and cargo will pick a single version per crate at link time anyway.
+multiple_crate_versions = "allow"
 
 [package.metadata.docs.rs]
 # Render the full API on docs.rs — including the `duckdb-1-5` / `duckdb-1-5-3`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,26 +35,15 @@ name = "quack_rs"
 crate-type = ["rlib"]
 
 [features]
-default = ["bundled"]
 
-## Compiles a bundled copy of DuckDB from C++ source via the `duckdb` crate's
-## `bundled` feature. Required for the default `bundled-test` path. Disable to
-## link against a pre-built libduckdb (see `bundled-test` docs for the env vars).
-bundled = ["duckdb?/bundled"]
-## Enables the `testing::InMemoryDb` helper which opens a real in-memory
-## DuckDB database for integration testing.
+## Enables the `testing::InMemoryDb` helper — a real in-memory DuckDB database
+## for SQL-level integration tests — by **compiling DuckDB from C++ source**
+## (the `duckdb` crate's `bundled` feature). No env vars required; cold builds
+## take ~5-10 min. This is the safe, reproducible default for SQL-level tests.
 ##
-## Two modes:
-## 1. With `bundled` (default): libduckdb is compiled from source by the
-##    `duckdb` crate. No env vars required; cold builds take ~5-10 min.
-## 2. Without `bundled` (`default-features = false, features = ["bundled-test"]`):
-##    quack-rs links against a pre-built libduckdb. Set one of:
-##    - `DUCKDB_DOWNLOAD_LIB=1` — libduckdb-sys downloads the prebuilt zip
-##      from the upstream DuckDB release (~30 MB, cached under `target/`).
-##      Recommended.
-##    - `DUCKDB_LIB_DIR=/path/to/libduckdb` — link against a libduckdb tree
-##      you already have (also set `DUCKDB_INCLUDE_DIR` if `duckdb.hpp` isn't
-##      sitting alongside the library).
+## Prefer `bundled-test-prebuilt` to link a pre-built libduckdb instead (faster,
+## no C++ compile). The two are mutually exclusive in intent; if both are
+## enabled, the source (`bundled`) build wins.
 ##
 ## Enabling this feature also initialises the `loadable-extension` dispatch
 ## table from the linked DuckDB symbols, so `InMemoryDb::open()` works in
@@ -72,9 +61,33 @@ bundled = ["duckdb?/bundled"]
 ##
 ## ```toml
 ## [dev-dependencies]
-## quack-rs = { version = "0.11", features = ["bundled-test"] }
+## quack-rs = { version = "0.13", features = ["bundled-test"] }
 ## ```
-bundled-test = ["dep:duckdb"]
+bundled-test = ["_duckdb-testing", "duckdb/bundled"]
+
+## Same capability as `bundled-test`, but links a **pre-built libduckdb** rather
+## than compiling DuckDB from C++ source — much faster, at the cost of supplying
+## the library yourself via exactly one of:
+##   - `DUCKDB_DOWNLOAD_LIB=1` — `libduckdb-sys` downloads the upstream DuckDB
+##     release zip (~40 MB, cached under `target/`). Recommended.
+##   - `DUCKDB_LIB_DIR=/path/to/libduckdb` — link a libduckdb tree you already
+##     have (also set `DUCKDB_INCLUDE_DIR` if `duckdb.hpp` isn't beside the lib).
+##
+## Requires `libduckdb-sys >= 1.10503` (which publishes the header directory via
+## `DEP_DUCKDB_INCLUDE`); older versions need `DUCKDB_INCLUDE_DIR` set explicitly.
+##
+## ```toml
+## [dev-dependencies]
+## quack-rs = { version = "0.13", features = ["bundled-test-prebuilt"] }
+## ```
+bundled-test-prebuilt = ["_duckdb-testing"]
+
+## Internal implementation detail — **do not enable directly.** Activates the
+## optional `duckdb` dependency and gates the `InMemoryDb` helper and its tests.
+## Enabled transitively by `bundled-test` (source build) and
+## `bundled-test-prebuilt` (pre-built libduckdb); those two differ only in
+## whether `duckdb/bundled` is also turned on.
+_duckdb-testing = ["dep:duckdb"]
 ## Enables wrappers for DuckDB 1.5.0 C API additions (e.g. scalar function local
 ## states, config option registration). Requires `libduckdb-sys >= 1.5.0` to be
 ## resolved by Cargo. Has no effect when compiled against libduckdb-sys 1.4.x.
@@ -122,13 +135,16 @@ duckdb = { version = ">=1.4.4, <2", optional = true }
 mutants = "0.0.4"
 
 [build-dependencies]
-# Used only when the `bundled-test` feature is active: compiles the thin C++
-# shim that calls DuckDB's internal CreateAPIv1() to initialise the
-# loadable-extension dispatch table from bundled DuckDB symbols.
+# Used only when `bundled-test` / `bundled-test-prebuilt` is active: compiles the
+# thin C++ shim that calls DuckDB's internal CreateAPIv1() to initialise the
+# loadable-extension dispatch table from the linked DuckDB symbols.
 cc = "1"
 
 [dev-dependencies]
-duckdb = { version = ">=1.4.4, <2" }
+# `duckdb` is intentionally NOT a dev-dependency: it is an optional regular
+# dependency activated only by `bundled-test` / `bundled-test-prebuilt`, so that
+# a plain `cargo test` (and every downstream consumer's lockfile) stays free of
+# the DuckDB + arrow tree.
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 # tempfile is version-pinned for reproducible dev builds. It was originally held
@@ -162,9 +178,6 @@ module_name_repetitions = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 return_self_not_must_use = "allow"
-# Transitive duplicates from arrow/ahash/ring trees — not under our control,
-# and cargo will pick a single version per crate at link time anyway.
-multiple_crate_versions = "allow"
 
 [package.metadata.docs.rs]
 # Render the full API on docs.rs — including the `duckdb-1-5` / `duckdb-1-5-3`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quack-rs"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.87.0"
 authors = ["Tom F. <tomf@tomtomtech.net>"]
@@ -61,7 +61,7 @@ crate-type = ["rlib"]
 ##
 ## ```toml
 ## [dev-dependencies]
-## quack-rs = { version = "0.13", features = ["bundled-test"] }
+## quack-rs = { version = "0.14", features = ["bundled-test"] }
 ## ```
 bundled-test = ["_duckdb-testing", "duckdb/bundled"]
 
@@ -78,7 +78,7 @@ bundled-test = ["_duckdb-testing", "duckdb/bundled"]
 ##
 ## ```toml
 ## [dev-dependencies]
-## quack-rs = { version = "0.13", features = ["bundled-test-prebuilt"] }
+## quack-rs = { version = "0.14", features = ["bundled-test-prebuilt"] }
 ## ```
 bundled-test-prebuilt = ["_duckdb-testing"]
 

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -148,19 +148,29 @@ For SQL-level assertions — verifying that a SQL macro produces the correct out
 or that a CREATE TABLE + INSERT + SELECT pipeline works — enable the `bundled-test`
 Cargo feature. This provides `InMemoryDb`, which wraps the `duckdb` crate's bundled
 DuckDB and automatically initialises the `loadable-extension` dispatch table before
-opening a connection (see [Pitfall P9](reference/pitfalls.md#p9)):
+opening a connection (see [Pitfall P9](reference/pitfalls.md#p9)).
+
+Two ways to consume it, picking the one that fits your build-time budget:
 
 ```toml
-# In your extension's Cargo.toml
+# Slow but zero-config: compile libduckdb from C++ source (~5-10 min cold).
 [dev-dependencies]
 quack-rs = { version = "0.13", features = ["bundled-test"] }
 ```
 
-> **Build time**: enabling `bundled-test` compiles a full copy of DuckDB from
-> source (the `duckdb` Rust crate with `features = ["bundled"]`) and a small
-> C++ shim via the `cc` build dependency. Expect a 2–5 minute incremental build
-> the first time, depending on your machine. This only affects the test build —
-> it has no impact on your extension's release binary.
+```toml
+# Fast: link against a pre-built libduckdb. Set DUCKDB_DOWNLOAD_LIB=1 at
+# build time and libduckdb-sys downloads the upstream release zip
+# (~30 MB, cached under target/). Or set DUCKDB_LIB_DIR=/path/to/libduckdb
+# if you already have one extracted.
+[dev-dependencies]
+quack-rs = { version = "0.13", default-features = false, features = ["bundled-test"] }
+```
+
+If your tests need to `LOAD` your own locally-built `.duckdb_extension`
+artifact, use `InMemoryDb::open_unsigned` instead of `open()` — the
+`allow_unsigned_extensions` config option is startup-only and can't be set
+via `SET` after the connection has opened.
 
 ```rust,no_run
 # #[cfg(feature = "bundled-test")]

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -150,22 +150,25 @@ Cargo feature. This provides `InMemoryDb`, which wraps the `duckdb` crate's bund
 DuckDB and automatically initialises the `loadable-extension` dispatch table before
 opening a connection (see [Pitfall P9](reference/pitfalls.md#p9)).
 
-Two ways to consume it, picking the one that fits your build-time budget:
+Two features expose `InMemoryDb`; pick the one that fits your build-time budget:
 
 ```toml
-# Slow but zero-config: compile libduckdb from C++ source (~5-10 min cold).
+# Zero-config but slow: compile libduckdb from C++ source (~5-10 min cold).
 [dev-dependencies]
 quack-rs = { version = "0.13", features = ["bundled-test"] }
 ```
 
 ```toml
-# Fast: link against a pre-built libduckdb. Set DUCKDB_DOWNLOAD_LIB=1 at
-# build time and libduckdb-sys downloads the upstream release zip
-# (~30 MB, cached under target/). Or set DUCKDB_LIB_DIR=/path/to/libduckdb
-# if you already have one extracted.
+# Fast: link against a pre-built libduckdb. Set DUCKDB_DOWNLOAD_LIB=1 at build
+# time and libduckdb-sys downloads the upstream release zip (~40 MB, cached
+# under target/); or set DUCKDB_LIB_DIR=/path/to/libduckdb if you already have
+# one extracted (requires libduckdb-sys >= 1.10503 for header auto-discovery).
 [dev-dependencies]
-quack-rs = { version = "0.13", default-features = false, features = ["bundled-test"] }
+quack-rs = { version = "0.13", features = ["bundled-test-prebuilt"] }
 ```
+
+Both keep `duckdb` out of a plain `cargo test` and out of your published
+crate's dependency tree — it is pulled in only when one of these features is on.
 
 If your tests need to `LOAD` your own locally-built `.duckdb_extension`
 artifact, use `InMemoryDb::open_unsigned` instead of `open()` — the

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,23 @@
 //! (`src/testing/bundled_api_init.cpp`) that exposes `DuckDB`'s internal
 //! `CreateAPIv1()` function as a C-linkage symbol.  The Rust side calls this
 //! at test startup to populate the `loadable-extension` dispatch table from
-//! the bundled `DuckDB` symbols, enabling `InMemoryDb` to work in `cargo test`.
+//! the linked `DuckDB` symbols, enabling `InMemoryDb` to work in `cargo test`.
+//!
+//! Two `bundled-test` modes are supported:
+//!
+//! 1. **`bundled-test + bundled` (default)**: `libduckdb-sys` extracts and
+//!    compiles `DuckDB` from C++ source.  Headers come from the extraction,
+//!    linking is handled by `libduckdb-sys` itself.
+//! 2. **`bundled-test` without `bundled`**: `libduckdb-sys` runs its
+//!    `build_linked` path, which can either download a pre-built libduckdb
+//!    (`DUCKDB_DOWNLOAD_LIB=1`, recommended) or use a user-supplied tree
+//!    (`DUCKDB_LIB_DIR`).  In `loadable-extension` mode `libduckdb-sys`
+//!    suppresses its `cargo:rustc-link-lib` emission, so quack-rs emits it
+//!    here.
+//!
+//! Header resolution prefers `DEP_DUCKDB_INCLUDE` (emitted via `cargo:include=`
+//! by `libduckdb-sys` >= 1.10503) and falls back to mode-specific probes for
+//! older versions, preserving the MSRV and dep-range of pre-1.10503 consumers.
 
 use std::env;
 use std::path::{Path, PathBuf};
@@ -25,8 +41,13 @@ fn main() {
     if env::var("CARGO_FEATURE_BUNDLED_TEST").is_err() {
         return;
     }
+    let bundled = env::var("CARGO_FEATURE_BUNDLED").is_ok();
 
-    let duckdb_include = find_duckdb_include();
+    if !bundled {
+        emit_prebuilt_link_lib();
+    }
+
+    let duckdb_include = resolve_duckdb_include(bundled);
 
     cc::Build::new()
         .cpp(true)
@@ -47,19 +68,91 @@ fn main() {
     println!("cargo:rerun-if-changed=src/testing/bundled_api_init.cpp");
 }
 
-/// Locates the `DuckDB` include directory from `libduckdb-sys`'s build output.
+/// In `bundled-test` without `bundled` mode, `libduckdb-sys` resolves the
+/// library location (downloaded or `DUCKDB_LIB_DIR`) and emits
+/// `cargo:rustc-link-search=...`, but its `loadable-extension` feature
+/// intentionally skips `cargo:rustc-link-lib=...` (the loaded extension's
+/// host process is normally responsible for providing libduckdb).  In
+/// `cargo test` we *are* the host, so we emit the link-lib directive here.
+fn emit_prebuilt_link_lib() {
+    println!("cargo:rerun-if-env-changed=DUCKDB_DOWNLOAD_LIB");
+    println!("cargo:rerun-if-env-changed=DUCKDB_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=DUCKDB_INCLUDE_DIR");
+    println!("cargo:rustc-link-lib=dylib=duckdb");
+}
+
+/// Resolves the include directory containing `duckdb.hpp`.  Tries (in order):
 ///
-/// Cargo places all crate build outputs under `target/{profile}/build/`.  We
-/// navigate up from our own `OUT_DIR` to that shared `build/` directory and
-/// search for a `libduckdb-sys-*` subdirectory that contains the extracted
-/// `DuckDB` source tree (present only when the `bundled` feature is active).
+/// 1. `DEP_DUCKDB_INCLUDE` — emitted by `libduckdb-sys >= 1.10503`.  Works in
+///    both bundled and `build_linked` (download / `DUCKDB_LIB_DIR`) paths.
+/// 2. Mode-specific fallbacks for older `libduckdb-sys`:
+///    - **bundled**: scan the Cargo build directory for the extracted source
+///      tree (the historical path used by quack-rs <= 0.12).
+///    - **!bundled**: `DUCKDB_INCLUDE_DIR`, then `DUCKDB_LIB_DIR` if it has
+///      `duckdb.hpp` alongside the library.  `DUCKDB_DOWNLOAD_LIB` is not
+///      probeable on pre-1.10503 (the download dir isn't exposed), so users
+///      on that mode must upgrade `libduckdb-sys` or set the dirs explicitly.
+fn resolve_duckdb_include(bundled: bool) -> PathBuf {
+    if let Some(dir) = env::var_os("DEP_DUCKDB_INCLUDE") {
+        let p = PathBuf::from(dir);
+        if p.join("duckdb.hpp").exists() {
+            return p;
+        }
+    }
+
+    if bundled {
+        find_duckdb_include_via_scan()
+    } else {
+        resolve_prebuilt_include_from_env()
+    }
+}
+
+/// Bundle-less, pre-1.10503 fallback: derive the include directory from
+/// the env vars the user is required to set anyway.
+fn resolve_prebuilt_include_from_env() -> PathBuf {
+    let mut inspected: Vec<(&str, PathBuf)> = Vec::new();
+    if let Some(inc) = env::var_os("DUCKDB_INCLUDE_DIR") {
+        let p = PathBuf::from(inc);
+        if p.join("duckdb.hpp").exists() {
+            return p;
+        }
+        inspected.push(("DUCKDB_INCLUDE_DIR", p));
+    }
+    if let Some(lib) = env::var_os("DUCKDB_LIB_DIR") {
+        let p = PathBuf::from(lib);
+        if p.join("duckdb.hpp").exists() {
+            return p;
+        }
+        inspected.push(("DUCKDB_LIB_DIR", p));
+    }
+    let inspected_report = if inspected.is_empty() {
+        "  (neither DUCKDB_INCLUDE_DIR nor DUCKDB_LIB_DIR was set)".to_string()
+    } else {
+        inspected
+            .iter()
+            .map(|(name, p)| format!("  {name}={} (no duckdb.hpp here)", p.display()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    panic!(
+        "quack-rs: bundled-test without bundled could not locate duckdb.hpp.\n\
+         Inspected:\n{inspected_report}\n\
+         Either upgrade libduckdb-sys to >= 1.10503 (which publishes the include\n\
+         directory via DEP_DUCKDB_INCLUDE), or point DUCKDB_INCLUDE_DIR /\n\
+         DUCKDB_LIB_DIR at a directory containing duckdb.hpp."
+    );
+}
+
+/// Legacy fallback for older `libduckdb-sys` versions that don't emit
+/// `cargo:include=`.  Navigates from `OUT_DIR` to the shared Cargo build
+/// directory and scans for `libduckdb-sys-*/out/duckdb/src/include`.
 ///
 /// **Build-order caveat**: Cargo runs build scripts as soon as their
 /// `[build-dependencies]` are ready — *before* regular `[dependencies]` are
 /// compiled.  This means `libduckdb-sys` (a regular dependency) may still be
 /// compiling when this function executes.  We therefore poll with a timeout
 /// to wait for the headers to appear.
-fn find_duckdb_include() -> PathBuf {
+fn find_duckdb_include_via_scan() -> PathBuf {
     // OUT_DIR  = .../target/{profile}/build/quack-rs-{hash}/out
     // We want  = .../target/{profile}/build/
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));

--- a/build.rs
+++ b/build.rs
@@ -3,23 +3,23 @@
 
 //! Build script for quack-rs.
 //!
-//! When the `bundled-test` feature is active this compiles a tiny C++ shim
-//! (`src/testing/bundled_api_init.cpp`) that exposes `DuckDB`'s internal
-//! `CreateAPIv1()` function as a C-linkage symbol.  The Rust side calls this
-//! at test startup to populate the `loadable-extension` dispatch table from
-//! the linked `DuckDB` symbols, enabling `InMemoryDb` to work in `cargo test`.
+//! When the `bundled-test` (or `bundled-test-prebuilt`) feature is active this
+//! compiles a tiny C++ shim (`src/testing/bundled_api_init.cpp`) that exposes
+//! `DuckDB`'s internal `CreateAPIv1()` function as a C-linkage symbol.  The Rust
+//! side calls this at test startup to populate the `loadable-extension` dispatch
+//! table from the linked `DuckDB` symbols, enabling `InMemoryDb` to work in
+//! `cargo test`.
 //!
-//! Two `bundled-test` modes are supported:
+//! Two modes are supported:
 //!
-//! 1. **`bundled-test + bundled` (default)**: `libduckdb-sys` extracts and
-//!    compiles `DuckDB` from C++ source.  Headers come from the extraction,
-//!    linking is handled by `libduckdb-sys` itself.
-//! 2. **`bundled-test` without `bundled`**: `libduckdb-sys` runs its
-//!    `build_linked` path, which can either download a pre-built libduckdb
-//!    (`DUCKDB_DOWNLOAD_LIB=1`, recommended) or use a user-supplied tree
-//!    (`DUCKDB_LIB_DIR`).  In `loadable-extension` mode `libduckdb-sys`
-//!    suppresses its `cargo:rustc-link-lib` emission, so quack-rs emits it
-//!    here.
+//! 1. **`bundled-test` (source)**: `libduckdb-sys` extracts and compiles
+//!    `DuckDB` from C++ source.  Headers come from the extraction, linking is
+//!    handled by `libduckdb-sys` itself.
+//! 2. **`bundled-test-prebuilt`**: `libduckdb-sys` runs its `build_linked` path,
+//!    which can either download a pre-built libduckdb (`DUCKDB_DOWNLOAD_LIB=1`,
+//!    recommended) or use a user-supplied tree (`DUCKDB_LIB_DIR`).  In
+//!    `loadable-extension` mode `libduckdb-sys` suppresses its
+//!    `cargo:rustc-link-lib` emission, so quack-rs emits it here.
 //!
 //! Header resolution prefers `DEP_DUCKDB_INCLUDE` (emitted via `cargo:include=`
 //! by `libduckdb-sys` >= 1.10503) and falls back to mode-specific probes for
@@ -37,17 +37,22 @@ fn main() {
         println!("cargo:rustc-link-lib=rstrtmgr");
     }
 
-    // Only needed when bundled-test is enabled.
-    if env::var("CARGO_FEATURE_BUNDLED_TEST").is_err() {
+    // Only needed when DuckDB testing support is enabled (either feature).
+    let source_build = env::var("CARGO_FEATURE_BUNDLED_TEST").is_ok();
+    let prebuilt_feature = env::var("CARGO_FEATURE_BUNDLED_TEST_PREBUILT").is_ok();
+    if !source_build && !prebuilt_feature {
         return;
     }
-    let bundled = env::var("CARGO_FEATURE_BUNDLED").is_ok();
+    // Prebuilt mode applies only when the prebuilt feature is on and the source
+    // (`bundled`) build is not — if both are enabled, `duckdb/bundled` wins and
+    // libduckdb-sys links the compiled-from-source library itself.
+    let prebuilt = prebuilt_feature && !source_build;
 
-    if !bundled {
+    if prebuilt {
         emit_prebuilt_link_lib();
     }
 
-    let duckdb_include = resolve_duckdb_include(bundled);
+    let duckdb_include = resolve_duckdb_include(!prebuilt);
 
     cc::Build::new()
         .cpp(true)
@@ -68,8 +73,8 @@ fn main() {
     println!("cargo:rerun-if-changed=src/testing/bundled_api_init.cpp");
 }
 
-/// In `bundled-test` without `bundled` mode, `libduckdb-sys` resolves the
-/// library location (downloaded or `DUCKDB_LIB_DIR`) and emits
+/// In `bundled-test-prebuilt` mode, `libduckdb-sys` resolves the library
+/// location (downloaded or `DUCKDB_LIB_DIR`) and emits
 /// `cargo:rustc-link-search=...`, but its `loadable-extension` feature
 /// intentionally skips `cargo:rustc-link-lib=...` (the loaded extension's
 /// host process is normally responsible for providing libduckdb).  In
@@ -86,9 +91,9 @@ fn emit_prebuilt_link_lib() {
 /// 1. `DEP_DUCKDB_INCLUDE` — emitted by `libduckdb-sys >= 1.10503`.  Works in
 ///    both bundled and `build_linked` (download / `DUCKDB_LIB_DIR`) paths.
 /// 2. Mode-specific fallbacks for older `libduckdb-sys`:
-///    - **bundled**: scan the Cargo build directory for the extracted source
-///      tree (the historical path used by quack-rs <= 0.12).
-///    - **!bundled**: `DUCKDB_INCLUDE_DIR`, then `DUCKDB_LIB_DIR` if it has
+///    - **source build (`bundled`)**: scan the Cargo build directory for the
+///      extracted source tree (the historical path used by quack-rs <= 0.12).
+///    - **prebuilt**: `DUCKDB_INCLUDE_DIR`, then `DUCKDB_LIB_DIR` if it has
 ///      `duckdb.hpp` alongside the library.  `DUCKDB_DOWNLOAD_LIB` is not
 ///      probeable on pre-1.10503 (the download dir isn't exposed), so users
 ///      on that mode must upgrade `libduckdb-sys` or set the dirs explicitly.

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "cc",
  "libduckdb-sys",

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -977,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/src/appender.rs
+++ b/src/appender.rs
@@ -232,7 +232,7 @@ impl Drop for Appender {
     }
 }
 
-#[cfg(all(test, feature = "bundled-test"))]
+#[cfg(all(test, feature = "_duckdb-testing"))]
 mod tests {
     use super::*;
 

--- a/src/client_context.rs
+++ b/src/client_context.rs
@@ -146,7 +146,7 @@ impl Drop for ClientContext {
     }
 }
 
-#[cfg(all(test, feature = "bundled-test"))]
+#[cfg(all(test, feature = "_duckdb-testing"))]
 mod tests {
     use super::*;
 

--- a/src/instance_cache.rs
+++ b/src/instance_cache.rs
@@ -129,7 +129,7 @@ impl Drop for InstanceCache {
     }
 }
 
-#[cfg(all(test, feature = "bundled-test"))]
+#[cfg(all(test, feature = "_duckdb-testing"))]
 mod tests {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,9 +120,11 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 
-// DuckDB's C API and duckdb_string_t layout assume 64-bit pointers.
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("quack-rs requires a 64-bit target (DuckDB does not support 32-bit platforms).");
+// quack-rs supports 64-bit targets and `wasm32-unknown-emscripten` (the
+// DuckDB-WASM target). The `duckdb_string_t` layout reserves 8 bytes for the
+// heap pointer regardless of pointer width — see `vector::string` for details.
+#[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
+compile_error!("quack-rs supports 64-bit targets and wasm32-unknown-emscripten.");
 
 pub mod aggregate;
 pub mod callback;

--- a/src/selection_vector.rs
+++ b/src/selection_vector.rs
@@ -114,7 +114,7 @@ impl Drop for SelectionVector {
     }
 }
 
-#[cfg(all(test, feature = "bundled-test"))]
+#[cfg(all(test, feature = "_duckdb-testing"))]
 mod tests {
     use super::*;
 

--- a/src/table_description.rs
+++ b/src/table_description.rs
@@ -162,7 +162,7 @@ impl Drop for TableDescription {
     }
 }
 
-#[cfg(all(test, feature = "bundled-test"))]
+#[cfg(all(test, feature = "_duckdb-testing"))]
 mod tests {
     use super::*;
 

--- a/src/testing/bundled_api_init.cpp
+++ b/src/testing/bundled_api_init.cpp
@@ -5,15 +5,23 @@
 //
 // Exposes DuckDB's internal CreateAPIv1() as a C-linkage function so that the
 // Rust test-initialisation code can call it to populate the loadable-extension
-// dispatch table from the bundled DuckDB symbols.
+// dispatch table from the linked DuckDB symbols.
 //
-// CreateAPIv1() is defined as an inline C++ function in
-// duckdb/main/capi/extension_api.hpp.  It constructs a duckdb_ext_api_v1
-// struct where every field is set to the corresponding bundled DuckDB C
-// function pointer — exactly what we need to initialise the Rust dispatch
-// table via duckdb_rs_extension_api_init().
+// CreateAPIv1() is an inline C++ function defined inside DuckDB's amalgamated
+// C++ header (`duckdb.hpp`). It constructs a duckdb_ext_api_v1 struct where
+// every field is set to the corresponding DuckDB C function pointer — exactly
+// what we need to initialise the Rust dispatch table via
+// duckdb_rs_extension_api_init().
+//
+// Including the amalgamation rather than the internal `extension_api.hpp` lets
+// the same shim compile in both modes:
+//   - bundled: against libduckdb-sys's extracted source tree
+//   - !bundled: against the official DuckDB release zip (downloaded by
+//     libduckdb-sys via DUCKDB_DOWNLOAD_LIB=1, or user-supplied via
+//     DUCKDB_LIB_DIR). The release zip ships `duckdb.hpp` but not
+//     `extension_api.hpp`.
 
-#include "duckdb/main/capi/extension_api.hpp"
+#include "duckdb.hpp"
 
 extern "C" duckdb_ext_api_v1 quack_rs_create_api_v1() {
     return CreateAPIv1();

--- a/src/testing/in_memory_db.rs
+++ b/src/testing/in_memory_db.rs
@@ -37,6 +37,17 @@
 //! quack-rs = { version = "0.13", features = ["bundled-test"] }
 //! ```
 //!
+//! To avoid the bundled libduckdb compile, opt out of `bundled` and let
+//! libduckdb-sys download the prebuilt zip instead:
+//!
+//! ```toml
+//! [dev-dependencies]
+//! quack-rs = { version = "0.13", default-features = false, features = ["bundled-test"] }
+//! ```
+//!
+//! Then build with `DUCKDB_DOWNLOAD_LIB=1` (or set `DUCKDB_LIB_DIR=...` if
+//! you have a libduckdb tree extracted locally).
+//!
 //! # Example
 //!
 //! ```rust,no_run
@@ -176,6 +187,42 @@ impl InMemoryDb {
         })
     }
 
+    /// Opens a new in-memory `DuckDB` database with `allow_unsigned_extensions`
+    /// enabled, so unsigned `.duckdb_extension` artifacts can be `LOAD`ed for
+    /// integration testing.
+    ///
+    /// `allow_unsigned_extensions` is a startup-only config option; it cannot
+    /// be toggled via `SET` after the database has opened. Use this constructor
+    /// when the test needs to `LOAD '/path/to/<your>.duckdb_extension'` against
+    /// an artifact you built locally (and therefore haven't signed).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the config can't be constructed or if `DuckDB` fails
+    /// to initialize an in-memory database.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "bundled-test")]
+    /// # {
+    /// use quack_rs::testing::InMemoryDb;
+    ///
+    /// let db = InMemoryDb::open_unsigned().unwrap();
+    /// // Loosen metadata checks too, since locally-built artifacts may have
+    /// // platform / DuckDB-version fields that don't match the host process.
+    /// db.execute_batch("SET allow_extensions_metadata_mismatch=true").unwrap();
+    /// db.execute_batch("LOAD '/path/to/my_ext.duckdb_extension'").unwrap();
+    /// # }
+    /// ```
+    pub fn open_unsigned() -> Result<Self, duckdb::Error> {
+        init_dispatch_table_once();
+        let config = duckdb::Config::default().allow_unsigned_extensions()?;
+        Ok(Self {
+            conn: duckdb::Connection::open_in_memory_with_flags(config)?,
+        })
+    }
+
     /// Executes one or more SQL statements separated by semicolons.
     ///
     /// Useful for `CREATE TABLE`, `INSERT`, `CREATE MACRO`, etc.
@@ -251,6 +298,24 @@ mod tests {
             .unwrap();
         let total: i64 = db.query_one("SELECT SUM(v) FROM t").unwrap();
         assert_eq!(total, 60);
+    }
+
+    #[test]
+    fn in_memory_db_open_unsigned_enables_allow_unsigned_extensions() {
+        let db = InMemoryDb::open_unsigned().expect("should open in-memory db");
+        let v: bool = db
+            .query_one("SELECT current_setting('allow_unsigned_extensions')")
+            .expect("should read config");
+        assert!(v);
+    }
+
+    #[test]
+    fn in_memory_db_open_does_not_enable_allow_unsigned_extensions() {
+        let db = InMemoryDb::open().expect("should open in-memory db");
+        let v: bool = db
+            .query_one("SELECT current_setting('allow_unsigned_extensions')")
+            .expect("should read config");
+        assert!(!v);
     }
 
     #[test]

--- a/src/testing/in_memory_db.rs
+++ b/src/testing/in_memory_db.rs
@@ -31,27 +31,29 @@
 //!
 //! # Enabling this feature
 //!
+//! Compile DuckDB from source (zero-config, ~5-10 min cold):
+//!
 //! ```toml
 //! # In your extension's Cargo.toml:
 //! [dev-dependencies]
 //! quack-rs = { version = "0.13", features = ["bundled-test"] }
 //! ```
 //!
-//! To avoid the bundled libduckdb compile, opt out of `bundled` and let
-//! libduckdb-sys download the prebuilt zip instead:
+//! …or link a pre-built libduckdb for a much faster build:
 //!
 //! ```toml
 //! [dev-dependencies]
-//! quack-rs = { version = "0.13", default-features = false, features = ["bundled-test"] }
+//! quack-rs = { version = "0.13", features = ["bundled-test-prebuilt"] }
 //! ```
 //!
-//! Then build with `DUCKDB_DOWNLOAD_LIB=1` (or set `DUCKDB_LIB_DIR=...` if
-//! you have a libduckdb tree extracted locally).
+//! With `bundled-test-prebuilt`, build with `DUCKDB_DOWNLOAD_LIB=1` (let
+//! libduckdb-sys download the prebuilt zip) or set `DUCKDB_LIB_DIR=...` to point
+//! at a libduckdb tree you already have extracted locally.
 //!
 //! # Example
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "bundled-test")]
+//! # #[cfg(feature = "_duckdb-testing")]
 //! # {
 //! use quack_rs::testing::InMemoryDb;
 //!
@@ -67,10 +69,12 @@
 
 // ── Dispatch-table initialisation ────────────────────────────────────────────
 //
-// When `bundled-test` is active, Cargo's feature-unification merges the
-// `loadable-extension` feature (required by the library to build as a DuckDB
-// extension) and the `bundled-full` feature (pulled in by `duckdb` with
-// `features = ["bundled"]`) into a single `libduckdb-sys` build.
+// When `bundled-test` / `bundled-test-prebuilt` is active, Cargo's
+// feature-unification merges the `loadable-extension` feature (required by the
+// library to build as a DuckDB extension) and the `duckdb`-provided
+// `libduckdb-sys` build (compiled from source for `bundled-test`, or linked
+// against a pre-built library for `bundled-test-prebuilt`) into a single
+// `libduckdb-sys` build.
 //
 // In `loadable-extension` mode every DuckDB C API call is routed through an
 // atomic function-pointer dispatch table that is normally populated by DuckDB
@@ -204,7 +208,7 @@ impl InMemoryDb {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "bundled-test")]
+    /// # #[cfg(feature = "_duckdb-testing")]
     /// # {
     /// use quack_rs::testing::InMemoryDb;
     ///
@@ -256,7 +260,7 @@ impl InMemoryDb {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "bundled-test")]
+    /// # #[cfg(feature = "_duckdb-testing")]
     /// # {
     /// use quack_rs::testing::InMemoryDb;
     ///

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -158,12 +158,12 @@ pub mod harness;
 pub mod mock_registrar;
 pub mod mock_vector;
 
-#[cfg(feature = "bundled-test")]
+#[cfg(feature = "_duckdb-testing")]
 pub mod in_memory_db;
 
 pub use harness::AggregateTestHarness;
 pub use mock_registrar::{CastRecord, MockRegistrar};
 pub use mock_vector::{MockDuckValue, MockVectorReader, MockVectorWriter};
 
-#[cfg(feature = "bundled-test")]
+#[cfg(feature = "_duckdb-testing")]
 pub use in_memory_db::InMemoryDb;

--- a/src/vector/string.rs
+++ b/src/vector/string.rs
@@ -102,9 +102,11 @@ impl<'a> DuckStringView<'a> {
     ///
     /// # Platform assumption
     ///
-    /// The pointer-format branch reads bytes 8–15 as a `usize` pointer, which
-    /// assumes a 64-bit platform (8-byte pointers). `DuckDB` itself only supports
-    /// 64-bit platforms, so this is a safe assumption.
+    /// The pointer-format branch reads bytes 8–15 as a `u64` and truncates to
+    /// `usize`. On 64-bit targets this is a lossless round-trip; on 32-bit
+    /// (DuckDB-WASM via `wasm32-unknown-emscripten`) the C union still reserves
+    /// 8 bytes for the pointer slot but only the lower 4 carry the address —
+    /// the upper 4 are padding/zero. `u64 as usize` returns those lower bytes.
     ///
     /// # Safety (internal)
     ///
@@ -116,11 +118,13 @@ impl<'a> DuckStringView<'a> {
             // Inline case: data starts at byte 4, length bytes follow
             Some(&self.bytes[4..4 + self.length])
         } else {
-            // Pointer case: bytes 8–15 contain the pointer (little-endian usize)
+            // Pointer case: bytes 8–15 hold the heap pointer in an 8-byte slot.
             // SAFETY: For pointer-format strings, bytes 8..16 hold a valid pointer
             // to heap memory allocated by DuckDB and valid for the vector's lifetime.
             let ptr_bytes: [u8; 8] = self.bytes[8..16].try_into().ok()?;
-            let ptr_val = usize::from_le_bytes(ptr_bytes) as *const u8;
+            // Read as u64 so this works regardless of `usize` width; truncating
+            // to `usize` is a no-op on 64-bit and yields the low 4 bytes on wasm32.
+            let ptr_val = u64::from_le_bytes(ptr_bytes) as usize as *const u8;
             if ptr_val.is_null() {
                 return None;
             }

--- a/src/vector/string.rs
+++ b/src/vector/string.rs
@@ -123,7 +123,10 @@ impl<'a> DuckStringView<'a> {
             // to heap memory allocated by DuckDB and valid for the vector's lifetime.
             let ptr_bytes: [u8; 8] = self.bytes[8..16].try_into().ok()?;
             // Read as u64 so this works regardless of `usize` width; truncating
-            // to `usize` is a no-op on 64-bit and yields the low 4 bytes on wasm32.
+            // to `usize` is a no-op on 64-bit and yields the low 4 bytes on wasm32
+            // (where the upper 4 bytes of the 8-byte slot are zero padding), so the
+            // truncation is intentional and lossless on every supported target.
+            #[allow(clippy::cast_possible_truncation)]
             let ptr_val = u64::from_le_bytes(ptr_bytes) as usize as *const u8;
             if ptr_val.is_null() {
                 return None;
@@ -237,7 +240,11 @@ mod tests {
         // Write prefix (first 4 bytes of the string)
         bytes[4..8].copy_from_slice(&long_str.as_bytes()[..4]);
         // Write pointer at bytes 8..16
-        let ptr_val = ptr as usize;
+        // Widen through `u64` so the 8-byte slot is filled on every target:
+        // on wasm32 `usize` is 4 bytes, so `usize::to_le_bytes()` would yield
+        // only 4 bytes and panic on this 8-byte copy (and would not match
+        // DuckDB's 16-byte layout that `as_bytes_unsafe` reads back as a `u64`).
+        let ptr_val = ptr as usize as u64;
         bytes[8..16].copy_from_slice(&ptr_val.to_le_bytes());
 
         let view = DuckStringView::from_bytes(&bytes);
@@ -275,7 +282,11 @@ mod tests {
         let mut bytes = [0u8; 16];
         bytes[..4].copy_from_slice(&u32::try_from(len).unwrap_or(u32::MAX).to_le_bytes());
         bytes[4..8].copy_from_slice(&long_str.as_bytes()[..4]);
-        let ptr_val = ptr as usize;
+        // Widen through `u64` so the 8-byte slot is filled on every target:
+        // on wasm32 `usize` is 4 bytes, so `usize::to_le_bytes()` would yield
+        // only 4 bytes and panic on this 8-byte copy (and would not match
+        // DuckDB's 16-byte layout that `as_bytes_unsafe` reads back as a `u64`).
+        let ptr_val = ptr as usize as u64;
         bytes[8..16].copy_from_slice(&ptr_val.to_le_bytes());
 
         // SAFETY: bytes is a valid pointer-format duckdb_string_t at idx 0.


### PR DESCRIPTION
## Summary

Cuts **v0.14.0** and resolves the two moderate Dependabot alerts on `main`. Backward-compatible feature release ⇒ minor bump (matches the repo's convention: features bump minor, fixes bump patch).

### Features (community contributions — thank you @killzoner)
- **`wasm32-unknown-emscripten` support** — removes the non-64-bit `compile_error!`; reads the `duckdb_string_t` pointer slot as `u64`→`usize` (lossless on 64-bit, low-4-bytes on wasm32). Original work in #94; CI now guards it.
- **`bundled-test-prebuilt` feature** — links a *pre-built* libduckdb instead of compiling DuckDB from source (`DUCKDB_DOWNLOAD_LIB=1` or `DUCKDB_LIB_DIR=…`). Original work in #90; redesigned so `duckdb` is fully optional and consumer lockfiles stay free of the DuckDB/arrow tree.
- **`InMemoryDb::open_unsigned()`** — opens an in-memory DB with `allow_unsigned_extensions=true` for loading locally-built unsigned extensions in integration tests.

### Security — clears the 2 Dependabot alerts on `main`
- **`tar` 0.4.45 → 0.4.46** in **both** lockfiles, resolving **GHSA-3pv8-6f4r-ffg2** ("PAX header desynchronization", Moderate). `tar` is a `libduckdb-sys` build-dependency, so it appears in the root **and** example `Cargo.lock` → **one alert each = the two moderate alerts**.
- This advisory is in the **GitHub Advisory Database but not RustSec**, so `cargo deny` (RustSec-only) never flagged it — which is exactly why it slipped the existing gate.

### CI hardening — closes that blind spot
- New **`osv-scan`** job runs `osv-scanner` (OSV.dev = GHSA **+** RustSec) over both lockfiles. Binary is version-pinned (v2.3.8) and checksum-verified. Verified locally: it **fails** on `main`'s `tar 0.4.45` (the 2 alerts) and **passes** on this branch.

## Folds in / supersedes
- Community: #94, #90 (@killzoner) — landed as their original commits (authorship preserved) plus follow-ups crediting them via `Co-authored-by`.
- Dependabot: #95, #96 (`tar`), #97 (`cc`), #93 (`codecov-action`) — folded in; the deps commit carries `Co-authored-by: dependabot[bot]`.

## ⚠️ Please merge with a **merge commit** (not squash)
Squashing would collapse @killzoner's commits and erase their authorship. A merge commit (or rebase-merge) preserves it. `Co-authored-by` trailers are also present as a backstop.

## Release steps after merge
1. CI green on `main`.
2. `git tag -s v0.14.0 && git push origin v0.14.0` → triggers the release pipeline. crates.io publish is gated behind the protected `crates-io` environment (manual approval), so tagging is safe.

## Verified locally
`cargo check --locked` (root + example), `cargo deny check`, `cargo fmt --check`, `osv-scanner` (clean), CHANGELOG release-notes extraction, and `wasm32-unknown-emscripten` lib check all pass.

https://claude.ai/code/session_014ywAYG15FrAfYJnD5JHVXD

---
_Generated by [Claude Code](https://claude.ai/code/session_014ywAYG15FrAfYJnD5JHVXD)_