### PR TITLE
fix(blob): preserve arbitrary bytes and add Value::as_blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Value::as_blob()` for copying arbitrary binary data from a `duckdb_value`.
+
+### Fixed
+
+- `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
+  an empty slice.
+
 ## [0.14.0] - 2026-06-07
 
 ### Added

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -240,9 +240,11 @@ Additionally, use `duckdb_get_function` to verify registration in development.
 
 ## P7: `duckdb_string_t` format is undocumented in Rust bindings
 
-**Status**: Handled by `VectorReader::read_str` and `read_duck_string`.
+**Status**: Handled by `VectorReader::read_str`, `VectorReader::read_blob`,
+`read_duck_string`, and `read_duck_blob`.
 
-**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes.
+**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes; BLOB
+reading silently drops bytes that are not valid UTF-8.
 
 **Root cause**: DuckDB stores strings in a 16-byte struct with two formats:
 - **Inline** (≤ 12 bytes): `[ len: u32 | data: [u8; 12] ]`
@@ -250,7 +252,9 @@ Additionally, use `duckdb_get_function` to verify registration in development.
 
 This is not documented in `libduckdb-sys`.
 
-**Fix**: Use `VectorReader::read_str` or `read_duck_string` which handle both formats.
+**Fix**: Use `VectorReader::read_str` or `read_duck_string` for UTF-8 text. Use
+`VectorReader::read_blob` or `read_duck_blob` for arbitrary binary data. All four
+handle both storage formats.
 
 ---
 

--- a/book/src/data/nulls-and-strings.md
+++ b/book/src/data/nulls-and-strings.md
@@ -100,6 +100,18 @@ unsafe { writer.write_varchar(row, my_str) };  // &str
 `write_varchar` copies the string bytes into DuckDB's managed storage. The
 `&str` reference is no longer needed after the call returns.
 
+### Reading BLOB values
+
+`BLOB` uses the same inline/pointer layout as `VARCHAR`, but may contain any
+bytes. Use `read_blob` so the data is not interpreted as UTF-8:
+
+```rust
+let bytes: &[u8] = unsafe { reader.read_blob(row) };
+```
+
+Like `read_str`, the returned slice borrows from the DuckDB vector and must not
+outlive the callback.
+
 ---
 
 ## Complete NULL-safe VARCHAR pattern

--- a/book/src/data/values-and-parameters.md
+++ b/book/src/data/values-and-parameters.md
@@ -43,6 +43,7 @@ unsafe extern "C" fn my_bind(info: duckdb_bind_info) {
 | Method | DuckDB type | Rust type |
 |--------|-------------|-----------|
 | `as_str()` | VARCHAR | `Result<String, ExtensionError>` |
+| `as_blob()` | BLOB | `Result<Vec<u8>, ExtensionError>` |
 | `as_i8()` | TINYINT | `i8` |
 | `as_i16()` | SMALLINT | `i16` |
 | `as_i32()` | INTEGER | `i32` |
@@ -57,7 +58,14 @@ unsafe extern "C" fn my_bind(info: duckdb_bind_info) {
 | `as_bool()` | BOOLEAN | `bool` |
 
 DuckDB will attempt to cast the value to the requested type. If the cast fails,
-numeric methods return `0` / `0.0` / `false`; `as_str()` returns an error.
+numeric methods return `0` / `0.0` / `false`; `as_str()` and `as_blob()` return
+an error if extraction fails.
+
+`as_blob()` copies the bytes into an owned `Vec<u8>` without UTF-8 validation:
+
+```rust
+let bytes = unsafe { bind_info.get_parameter_value(0) }.as_blob()?;
+```
 
 ### Null-safe convenience variants
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,6 +10,15 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Value::as_blob()` for copying arbitrary binary data from a `duckdb_value`.
+
+### Fixed
+
+- `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
+  an empty slice.
+
 ## [0.13.0] — 2026-05-24
 
 ### Added

--- a/book/src/reference/pitfalls.md
+++ b/book/src/reference/pitfalls.md
@@ -271,15 +271,18 @@ often ignored. When it returns `DuckDBError`, the function set is not registered
 
 ## P7: `duckdb_string_t` format is undocumented
 
-**Status**: Handled by `VectorReader::read_str` and `DuckStringView`.
+**Status**: Handled by `VectorReader::read_str`, `VectorReader::read_blob`, and
+`DuckStringView`.
 
-**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes.
+**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes; BLOB
+reading silently drops bytes that are not valid UTF-8.
 
 **Root cause**: DuckDB stores strings in a 16-byte struct with two formats
 (inline ≤ 12 bytes, pointer > 12 bytes) that are not documented in
 `libduckdb-sys`.
 
-**Fix**: Use `VectorReader::read_str(row)`. See
+**Fix**: Use `VectorReader::read_str(row)` for UTF-8 text and
+`VectorReader::read_blob(row)` for arbitrary binary data. See
 [NULL Handling & Strings](../data/nulls-and-strings.md).
 
 ---

--- a/src/value.rs
+++ b/src/value.rs
@@ -27,6 +27,8 @@
 //! }
 //! ```
 
+mod blob;
+
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
@@ -60,6 +62,7 @@ use crate::error::ExtensionError;
 ///
 /// Use typed accessors to extract the underlying data:
 /// - [`as_str`][Value::as_str] — VARCHAR → `String`
+/// - [`as_blob`][Value::as_blob] — BLOB → `Vec<u8>`
 /// - [`as_i32`][Value::as_i32] — INTEGER → `i32`
 /// - [`as_i64`][Value::as_i64] — BIGINT → `i64`
 /// - [`as_f32`][Value::as_f32] — FLOAT → `f32`

--- a/src/value/blob.rs
+++ b/src/value/blob.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+use libduckdb_sys::{duckdb_blob, duckdb_free, duckdb_get_blob};
+
+use super::Value;
+use crate::error::ExtensionError;
+
+fn blob_size(blob: &duckdb_blob) -> Result<Option<usize>, ExtensionError> {
+    if blob.data.is_null() {
+        return if blob.size == 0 {
+            Ok(None)
+        } else {
+            Err(ExtensionError::new("duckdb_get_blob returned null data"))
+        };
+    }
+    usize::try_from(blob.size)
+        .map(Some)
+        .map_err(|_| ExtensionError::new("duckdb_get_blob returned an unsupported blob size"))
+}
+
+#[mutants::skip] // DuckDB allocator effects are not observable from safe Rust tests.
+unsafe fn free_blob_data(data: *mut core::ffi::c_void) {
+    if !data.is_null() {
+        unsafe { duckdb_free(data) };
+    }
+}
+
+impl Value {
+    /// Extracts the value as an owned `Vec<u8>` (`BLOB`).
+    ///
+    /// `DuckDB` allocates the blob's backing buffer; this method copies it into
+    /// an owned `Vec<u8>` and frees the original with `duckdb_free`. The bytes
+    /// are copied without UTF-8 validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExtensionError` if the value handle is null, `duckdb_get_blob`
+    /// returns a null data pointer for a non-empty blob, or the blob size cannot
+    /// be represented by `usize` on the current platform.
+    pub fn as_blob(&self) -> Result<Vec<u8>, ExtensionError> {
+        if self.raw.is_null() {
+            return Err(ExtensionError::new("Value is null"));
+        }
+        // SAFETY: self.raw is a valid duckdb_value per constructor contract.
+        let blob: duckdb_blob = unsafe { duckdb_get_blob(self.raw) };
+        let size = match blob_size(&blob) {
+            Ok(None) => return Ok(Vec::new()),
+            Ok(Some(size)) => size,
+            Err(error) => {
+                // SAFETY: non-null blob data was allocated by DuckDB. The
+                // helper also accepts null for the invalid-pointer error path.
+                unsafe { free_blob_data(blob.data) };
+                return Err(error);
+            }
+        };
+        // SAFETY: blob.data is a DuckDB-allocated buffer of exactly `blob.size`
+        // bytes, valid until we free it below.
+        let slice = unsafe { std::slice::from_raw_parts(blob.data.cast::<u8>(), size) };
+        let out = slice.to_vec();
+        // SAFETY: blob.data was allocated by DuckDB and must be freed with duckdb_free.
+        unsafe { free_blob_data(blob.data) };
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_size_null_empty_blob_is_valid() {
+        let blob = duckdb_blob {
+            data: std::ptr::null_mut(),
+            size: 0,
+        };
+        assert!(matches!(blob_size(&blob), Ok(None)));
+    }
+
+    #[test]
+    fn blob_size_null_non_empty_blob_is_invalid() {
+        let blob = duckdb_blob {
+            data: std::ptr::null_mut(),
+            size: 1,
+        };
+        assert!(blob_size(&blob).is_err());
+    }
+
+    #[test]
+    fn null_value_as_blob_returns_error() {
+        let value = unsafe { Value::from_raw(std::ptr::null_mut()) };
+        assert!(value.as_blob().is_err());
+    }
+
+    #[cfg(feature = "_duckdb-testing")]
+    #[test]
+    fn blob_value_non_utf8_bytes_round_trip() {
+        let _db = crate::testing::InMemoryDb::open().expect("should initialize DuckDB");
+        let payload = [
+            0x80u8, 0xF0, 0x01, 0x42, 0xFF, 0x00, 0xFE, 0x7F, 0xAA, 0x55, 0xC0, 0xAF, 0x90,
+        ];
+        let len = u64::try_from(payload.len()).expect("test payload length fits in u64");
+        // SAFETY: payload points to `len` readable bytes for the duration of the call.
+        let raw = unsafe { libduckdb_sys::duckdb_create_blob(payload.as_ptr(), len) };
+        // SAFETY: duckdb_create_blob returns an owned value handle.
+        let value = unsafe { Value::from_raw(raw) };
+
+        assert_eq!(value.as_blob().expect("blob should be readable"), payload);
+    }
+
+    #[cfg(feature = "_duckdb-testing")]
+    #[test]
+    fn blob_value_empty_bytes_round_trip() {
+        let _db = crate::testing::InMemoryDb::open().expect("should initialize DuckDB");
+        let payload = [];
+        // SAFETY: payload is readable for zero bytes for the duration of the call.
+        let raw = unsafe { libduckdb_sys::duckdb_create_blob(payload.as_ptr(), 0) };
+        // SAFETY: duckdb_create_blob returns an owned value handle.
+        let value = unsafe { Value::from_raw(raw) };
+
+        assert!(value.as_blob().expect("blob should be readable").is_empty());
+    }
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -28,7 +28,7 @@ pub mod validity;
 pub mod writer;
 
 pub use reader::VectorReader;
-pub use string::{read_duck_string, DuckStringView};
+pub use string::{read_duck_blob, read_duck_string, DuckStringView};
 pub use struct_reader::StructReader;
 pub use struct_writer::StructWriter;
 pub use validity::ValidityBitmap;

--- a/src/vector/reader.rs
+++ b/src/vector/reader.rs
@@ -300,6 +300,8 @@ impl VectorReader {
     /// VARCHAR (inline for ≤12 bytes, pointer for larger values). The returned
     /// slice borrows from the vector's data buffer.
     ///
+    /// The bytes are returned without UTF-8 validation.
+    ///
     /// # Safety
     ///
     /// - `idx` must be less than `self.row_count()`.
@@ -307,7 +309,7 @@ impl VectorReader {
     /// - The pointed-to memory must be valid for the lifetime of the returned slice.
     pub unsafe fn read_blob(&self, idx: usize) -> &[u8] {
         // SAFETY: BLOB uses the same duckdb_string_t layout as VARCHAR.
-        unsafe { crate::vector::string::read_duck_string(self.data, idx).as_bytes() }
+        unsafe { crate::vector::string::read_duck_blob(self.data, idx) }
     }
 
     /// Reads a `UUID` value at row `idx` as an `i128`.

--- a/src/vector/string.rs
+++ b/src/vector/string.rs
@@ -3,7 +3,7 @@
 // My way of giving something small back to the open source community
 // and encouraging more Rust development!
 
-//! `DuckDB` `VARCHAR` (`duckdb_string_t`) reading utilities.
+//! `DuckDB` `VARCHAR` and `BLOB` (`duckdb_string_t`) reading utilities.
 //!
 //! # Pitfall P7: Undocumented `duckdb_string_t` format
 //!
@@ -184,6 +184,28 @@ pub unsafe fn read_duck_string<'a>(data: *const u8, idx: usize) -> &'a str {
     DuckStringView::from_bytes(raw_bytes).as_str().unwrap_or("")
 }
 
+/// Reads a `DuckDB` `BLOB` value at the given row index.
+///
+/// Returns the raw bytes without UTF-8 validation, or an empty slice if a
+/// pointer-format value contains a null pointer. `BLOB` and `VARCHAR` share the
+/// same `duckdb_string_t` layout (inline for ≤ 12 bytes, pointer otherwise).
+///
+/// # Safety
+///
+/// - `data` must point at a `DuckDB` BLOB (or VARCHAR) vector's data buffer.
+/// - `idx` must be within bounds of the vector.
+/// - For pointer-format blobs, the heap data must be valid for the lifetime of
+///   the returned slice.
+pub unsafe fn read_duck_blob<'a>(data: *const u8, idx: usize) -> &'a [u8] {
+    // SAFETY: each duckdb_string_t is exactly DUCK_STRING_SIZE bytes.
+    let str_ptr = unsafe { data.add(idx * DUCK_STRING_SIZE) };
+    let raw_bytes: &'a [u8; DUCK_STRING_SIZE] =
+        unsafe { &*str_ptr.cast::<[u8; DUCK_STRING_SIZE]>() };
+    DuckStringView::from_bytes(raw_bytes)
+        .as_bytes_unsafe()
+        .unwrap_or(&[])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +251,33 @@ mod tests {
     }
 
     #[test]
+    fn read_duck_blob_preserves_non_utf8_inline_bytes() {
+        let payload = [0x80u8, 0xF0, 0x01, 0x42];
+        let mut bytes = [0u8; 16];
+        let len = u32::try_from(payload.len()).unwrap_or(u32::MAX);
+        bytes[..4].copy_from_slice(&len.to_le_bytes());
+        bytes[4..4 + payload.len()].copy_from_slice(&payload);
+
+        assert_eq!(unsafe { read_duck_blob(bytes.as_ptr(), 0) }, &payload);
+        assert_eq!(unsafe { read_duck_string(bytes.as_ptr(), 0) }, "");
+    }
+
+    #[test]
+    fn read_duck_blob_preserves_non_utf8_pointer_bytes() {
+        let payload = [
+            0x80u8, 0xF0, 0x01, 0x42, 0xFF, 0x00, 0xFE, 0x7F, 0xAA, 0x55, 0xC0, 0xAF, 0x90,
+        ];
+        let mut bytes = [0u8; 16];
+        let len = u32::try_from(payload.len()).unwrap_or(u32::MAX);
+        bytes[..4].copy_from_slice(&len.to_le_bytes());
+        bytes[4..8].copy_from_slice(&payload[..4]);
+        let ptr = payload.as_ptr() as usize as u64;
+        bytes[8..16].copy_from_slice(&ptr.to_le_bytes());
+
+        assert_eq!(unsafe { read_duck_blob(bytes.as_ptr(), 0) }, &payload);
+    }
+
+    #[test]
     fn pointer_format_string() {
         let long_str = "this is a longer string that exceeds 12 bytes";
         let len = long_str.len();
@@ -262,6 +311,7 @@ mod tests {
         let view = DuckStringView::from_bytes(&bytes);
         // Null pointer for long string should return None
         assert!(view.as_str().is_none());
+        assert!(unsafe { read_duck_blob(bytes.as_ptr(), 0) }.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`VectorReader::read_blob` reused the VARCHAR reader, so non-UTF-8 BLOB data was silently returned as an empty slice. This PR reads vector BLOBs as raw bytes and adds `Value::as_blob()` for owned `duckdb_value` extraction.

## Type of change

- [x] Bug fix
- [x] Additive public API
- [x] Documentation update

## Changes

- Add `read_duck_blob` and route `VectorReader::read_blob` through it. Tests cover inline and pointer-backed non-UTF-8 values; `StructReader` benefits through delegation.
- Add `Value::as_blob() -> Result<Vec<u8>, ExtensionError>`, including DuckDB allocation cleanup, empty BLOB support, null/size validation, and real FFI round-trip tests.
- Update both changelogs, the book, and the `duckdb_string_t` pitfall documentation.

The `Value` implementation and tests live in focused `src/value/blob.rs`, keeping the existing `src/value.rs` effectively unchanged in size (564 lines on `main`, 567 here).

## Compatibility

- Existing `read_blob` signatures are unchanged.
- `Value::as_blob` and `read_duck_blob` are additive.
- VARCHAR behavior is unchanged.

## Verification

- `cargo test --all-targets --locked` — passed
- Prebuilt DuckDB + `duckdb-1-5-3` all-target tests — passed
- Clippy, rustdoc, rustfmt — passed
- Rust 1.87.0 MSRV check — passed
- `wasm32-unknown-emscripten` checks — passed
- mdBook 0.4.40 build — passed
- cargo-mutants — 7/7 caught

## Checklist

- [x] New code has tests and rustdoc
- [x] All new `unsafe` blocks have `// SAFETY:` comments
- [x] No panic/unwind path added across FFI
- [x] `CHANGELOG.md` and book documentation updated
- [x] New FFI pitfall documented
- [x] New file has an SPDX header and is under 500 lines
- [ ] `src/value.rs` remains over 500 lines, as it already is on `main`; this PR adds only 3 lines to it
