### PR TITLE
Release v0.15.0 — binary-safe blob I/O (#104), dependency/Actions/security updates, DuckDB 1.5.4

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check --all-targets
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-targets
@@ -66,7 +66,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-targets --features bundled-test
@@ -80,7 +80,7 @@ jobs:
     name: Test bundled-test-prebuilt (prebuilt libduckdb)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Download pre-built libduckdb
@@ -104,7 +104,7 @@ jobs:
     name: Test duckdb-1-5 / duckdb-1-5-3 features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check --all-targets --features duckdb-1-5
@@ -118,7 +118,7 @@ jobs:
     name: WASM (wasm32-unknown-emscripten)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: wasm32-unknown-emscripten
@@ -134,7 +134,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # beta
         with:
           toolchain: beta
@@ -161,7 +161,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt
@@ -171,7 +171,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # Use --features duckdb-1-5-3 (implies duckdb-1-5) instead of --all-features
@@ -186,7 +186,7 @@ jobs:
     name: MSRV (1.87.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # 1.87.0
         with:
           toolchain: "1.87.0"
@@ -197,7 +197,7 @@ jobs:
     name: Benchmark (compile check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo bench --no-run
@@ -210,7 +210,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check --manifest-path examples/hello-ext/Cargo.toml --all-targets
@@ -223,7 +223,7 @@ jobs:
     name: Scaffold (compile check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Verify scaffold output compiles
@@ -237,7 +237,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build hello-ext as cdylib
@@ -269,7 +269,7 @@ jobs:
     name: Extension load test (DuckDB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build hello-ext as cdylib
@@ -297,7 +297,7 @@ jobs:
     name: Publish dry-run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: cargo publish --dry-run
@@ -307,7 +307,7 @@ jobs:
     name: Security (cargo-deny)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-targets: false
@@ -325,7 +325,7 @@ jobs:
     name: Security (OSV / GHSA)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install osv-scanner (pinned, checksum-verified)
         run: |
           VER=2.3.8
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Download pre-built libduckdb
         # Keep the version in sync with the `duckdb` / `libduckdb-sys` dependency
-        # (1.10503.x == DuckDB v1.5.3). The release zip ships libduckdb.so and
+        # (1.10504.x == DuckDB v1.5.4). The release zip ships libduckdb.so and
         # duckdb.hpp; the C++ shim is compiled against the latter.
         run: |
-          curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.5.3/libduckdb-linux-amd64.zip -o "${{ runner.temp }}/libduckdb.zip"
+          curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.5.4/libduckdb-linux-amd64.zip -o "${{ runner.temp }}/libduckdb.zip"
           mkdir -p "${{ runner.temp }}/libduckdb"
           unzip -o "${{ runner.temp }}/libduckdb.zip" -d "${{ runner.temp }}/libduckdb"
       - name: Test against pre-built libduckdb

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
     name: Test coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Cache Cargo registry and mdBook binary
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
       crate_name:    ${{ steps.meta.outputs.crate_name }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Extract version metadata
         id: meta
@@ -158,7 +158,7 @@ jobs:
             toolchain: "1.87.0"
             command: cargo check
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -175,7 +175,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-targets: false
@@ -200,7 +200,7 @@ jobs:
     outputs:
       crate_file: ${{ steps.pkg.outputs.crate_file }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
@@ -251,7 +251,7 @@ jobs:
     needs: [ci, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: cargo publish --dry-run
@@ -270,7 +270,7 @@ jobs:
     permissions:
       contents: write  # create release, upload assets
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -388,7 +388,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
       # SLSA Level 2 build provenance — creates a signed attestation linking
       # the .crate artifact to this workflow run, verifiable with `gh attestation verify`.
       - name: Attest build provenance (SLSA)
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: target/package/*.crate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
   an empty slice.
 
+### Changed
+
+- Dev/CI DuckDB bumped to **1.5.4** — `libduckdb-sys` / `duckdb` 1.10503.1 →
+  1.10504.0 in the root lockfile, the `hello-ext` example lockfile, and the
+  `bundled-test-prebuilt` CI download (`v1.5.3` → `v1.5.4`). 1.5.4 is a bugfix
+  release in the 1.5.x line; its C extension API version is unchanged (`v1.2.0`,
+  verified from `duckdb_extension.h`), so `DUCKDB_API_VERSION` is unchanged and
+  the public `libduckdb-sys` dependency range (`>=1.4.4, <2`) is untouched —
+  downstream consumers are unaffected.
+
+### Security
+
+- **`crossbeam-epoch` 0.9.18 → 0.9.20** (root lockfile), resolving
+  **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer`
+  impl). Reaches the tree only as a dev-dependency via `criterion → rayon →
+  crossbeam-deque`.
+- **`quinn-proto` 0.11.14 → 0.11.15** (root and example lockfiles), resolving
+  **RUSTSEC-2026-0185** (CVSS 7.5). Reaches the lockfiles via
+  `libduckdb-sys → reqwest → quinn` (feature-union only; the loadable-extension
+  build never links it).
+
+### CI / tooling
+
+- Refreshed SHA-pinned GitHub Actions via Dependabot: `actions/checkout`
+  v6.0.2 → v7.0.0, `codecov/codecov-action` v6.0.1 → v7.0.0, `actions/cache`
+  v5.0.5 → v6.1.0, and `actions/attest-build-provenance` v4.1.0 → v4.1.1. Also
+  bumped the `cc` build-dependency 1.2.63 → 1.2.64.
+
 ## [0.14.0] - 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-16
+
 ### Added
 
 - `Value::as_blob()` for copying arbitrary binary data from a `duckdb_value`.
+  (Thanks @adonm.)
 
 ### Fixed
 
 - `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
-  an empty slice.
+  an empty slice. (Thanks @adonm.)
 
 ### Changed
 
@@ -1140,7 +1143,8 @@ the workspace `Cargo.lock` and `examples/hello-ext/Cargo.lock`.
 - CI pipeline: check, test, clippy, fmt, doc, MSRV, bench-compile
 - `SECURITY.md` vulnerability disclosure policy
 
-[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/tomtom215/quack-rs/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/tomtom215/quack-rs/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...v0.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Value::as_blob()` for copying arbitrary binary data from a `duckdb_value`.
+
+### Fixed
+
+- `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
+  an empty slice.
+
 ## [0.14.0] - 2026-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cc",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -654,7 +654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1910,7 +1910,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2085,7 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2190,7 +2190,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2604,7 +2604,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10503.1"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
+checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
 dependencies = [
  "arrow",
  "cast",
@@ -1209,9 +1209,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10503.1"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quack-rs"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.87.0"
 authors = ["Tom F. <tomf@tomtomtech.net>"]
@@ -61,7 +61,7 @@ crate-type = ["rlib"]
 ##
 ## ```toml
 ## [dev-dependencies]
-## quack-rs = { version = "0.14", features = ["bundled-test"] }
+## quack-rs = { version = "0.15", features = ["bundled-test"] }
 ## ```
 bundled-test = ["_duckdb-testing", "duckdb/bundled"]
 
@@ -78,7 +78,7 @@ bundled-test = ["_duckdb-testing", "duckdb/bundled"]
 ##
 ## ```toml
 ## [dev-dependencies]
-## quack-rs = { version = "0.14", features = ["bundled-test-prebuilt"] }
+## quack-rs = { version = "0.15", features = ["bundled-test-prebuilt"] }
 ## ```
 bundled-test-prebuilt = ["_duckdb-testing"]
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -240,9 +240,11 @@ Additionally, use `duckdb_get_function` to verify registration in development.
 
 ## P7: `duckdb_string_t` format is undocumented in Rust bindings
 
-**Status**: Handled by `VectorReader::read_str` and `read_duck_string`.
+**Status**: Handled by `VectorReader::read_str`, `VectorReader::read_blob`,
+`read_duck_string`, and `read_duck_blob`.
 
-**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes.
+**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes; BLOB
+reading silently drops bytes that are not valid UTF-8.
 
 **Root cause**: DuckDB stores strings in a 16-byte struct with two formats:
 - **Inline** (≤ 12 bytes): `[ len: u32 | data: [u8; 12] ]`
@@ -250,7 +252,9 @@ Additionally, use `duckdb_get_function` to verify registration in development.
 
 This is not documented in `libduckdb-sys`.
 
-**Fix**: Use `VectorReader::read_str` or `read_duck_string` which handle both formats.
+**Fix**: Use `VectorReader::read_str` or `read_duck_string` for UTF-8 text. Use
+`VectorReader::read_blob` or `read_duck_blob` for arbitrary binary data. All four
+handle both storage formats.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,10 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 0.13.x  | Yes                |
-| 0.12.x  | Yes                |
+| 0.15.x  | Yes                |
+| 0.14.x  | Yes                |
+| 0.13.x  | No (end-of-life)   |
+| 0.12.x  | No (end-of-life)   |
 | 0.11.x  | No (end-of-life)   |
 | 0.10.x  | No (end-of-life)   |
 | 0.9.x   | No (end-of-life)   |

--- a/book/src/data/nulls-and-strings.md
+++ b/book/src/data/nulls-and-strings.md
@@ -100,6 +100,18 @@ unsafe { writer.write_varchar(row, my_str) };  // &str
 `write_varchar` copies the string bytes into DuckDB's managed storage. The
 `&str` reference is no longer needed after the call returns.
 
+### Reading BLOB values
+
+`BLOB` uses the same inline/pointer layout as `VARCHAR`, but may contain any
+bytes. Use `read_blob` so the data is not interpreted as UTF-8:
+
+```rust
+let bytes: &[u8] = unsafe { reader.read_blob(row) };
+```
+
+Like `read_str`, the returned slice borrows from the DuckDB vector and must not
+outlive the callback.
+
 ---
 
 ## Complete NULL-safe VARCHAR pattern

--- a/book/src/data/values-and-parameters.md
+++ b/book/src/data/values-and-parameters.md
@@ -43,6 +43,7 @@ unsafe extern "C" fn my_bind(info: duckdb_bind_info) {
 | Method | DuckDB type | Rust type |
 |--------|-------------|-----------|
 | `as_str()` | VARCHAR | `Result<String, ExtensionError>` |
+| `as_blob()` | BLOB | `Result<Vec<u8>, ExtensionError>` |
 | `as_i8()` | TINYINT | `i8` |
 | `as_i16()` | SMALLINT | `i16` |
 | `as_i32()` | INTEGER | `i32` |
@@ -57,7 +58,14 @@ unsafe extern "C" fn my_bind(info: duckdb_bind_info) {
 | `as_bool()` | BOOLEAN | `bool` |
 
 DuckDB will attempt to cast the value to the requested type. If the cast fails,
-numeric methods return `0` / `0.0` / `false`; `as_str()` returns an error.
+numeric methods return `0` / `0.0` / `false`; `as_str()` and `as_blob()` return
+an error if extraction fails.
+
+`as_blob()` copies the bytes into an owned `Vec<u8>` without UTF-8 validation:
+
+```rust
+let bytes = unsafe { bind_info.get_parameter_value(0) }.as_blob()?;
+```
 
 ### Null-safe convenience variants
 

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,6 +10,15 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Value::as_blob()` for copying arbitrary binary data from a `duckdb_value`.
+
+### Fixed
+
+- `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
+  an empty slice.
+
 ## [0.13.0] — 2026-05-24
 
 ### Added

--- a/book/src/reference/changelog.md
+++ b/book/src/reference/changelog.md
@@ -10,14 +10,94 @@ quack-rs adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-07-16
+
 ### Added
 
 - `Value::as_blob()` for copying arbitrary binary data from a `duckdb_value`.
+  (Thanks @adonm.)
 
 ### Fixed
 
 - `VectorReader::read_blob()` now preserves non-UTF-8 bytes instead of returning
-  an empty slice.
+  an empty slice. (Thanks @adonm.)
+
+### Changed
+
+- Dev/CI DuckDB bumped to **1.5.4** — `libduckdb-sys` / `duckdb` 1.10503.1 →
+  1.10504.0 in the root lockfile, the `hello-ext` example lockfile, and the
+  `bundled-test-prebuilt` CI download (`v1.5.3` → `v1.5.4`). 1.5.4 is a bugfix
+  release in the 1.5.x line; its C extension API version is unchanged (`v1.2.0`,
+  verified from `duckdb_extension.h`), so `DUCKDB_API_VERSION` is unchanged and
+  the public `libduckdb-sys` dependency range (`>=1.4.4, <2`) is untouched —
+  downstream consumers are unaffected.
+
+### Security
+
+- **`crossbeam-epoch` 0.9.18 → 0.9.20** (root lockfile), resolving
+  **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer`
+  impl). Reaches the tree only as a dev-dependency via `criterion → rayon →
+  crossbeam-deque`.
+- **`quinn-proto` 0.11.14 → 0.11.15** (root and example lockfiles), resolving
+  **RUSTSEC-2026-0185** (CVSS 7.5). Reaches the lockfiles via
+  `libduckdb-sys → reqwest → quinn` (feature-union only; the loadable-extension
+  build never links it).
+
+### CI / tooling
+
+- Refreshed SHA-pinned GitHub Actions via Dependabot: `actions/checkout`
+  v6.0.2 → v7.0.0, `codecov/codecov-action` v6.0.1 → v7.0.0, `actions/cache`
+  v5.0.5 → v6.1.0, and `actions/attest-build-provenance` v4.1.0 → v4.1.1. Also
+  bumped the `cc` build-dependency 1.2.63 → 1.2.64.
+
+## [0.14.0] — 2026-06-07
+
+### Added
+
+- **`wasm32-unknown-emscripten` support** (the DuckDB-WASM target). The crate no
+  longer hard-rejects non-64-bit targets with a top-level `compile_error!`, and
+  the `duckdb_string_t` pointer slot is read as a `u64` then narrowed to `usize`
+  — lossless on 64-bit, and on wasm32 it yields the low 4 bytes of the 8-byte
+  slot (the upper 4 are zero padding in DuckDB's 16-byte layout). The full public
+  API, including the `duckdb-1-5-3` surface, `cargo check`s for
+  `wasm32-unknown-emscripten`; CI now guards this. (Thanks @killzoner.)
+- **`bundled-test-prebuilt` feature** — links a *pre-built* libduckdb instead of
+  compiling DuckDB from C++ source, for a much faster test build. Supply the
+  library via `DUCKDB_DOWNLOAD_LIB=1` (`libduckdb-sys` downloads the upstream
+  release zip) or `DUCKDB_LIB_DIR=...` (a libduckdb tree you already have).
+  `bundled-test` continues to compile DuckDB from source. (Thanks @killzoner.)
+- `InMemoryDb::open_unsigned()` opens an in-memory database with
+  `allow_unsigned_extensions=true`, allowing downstream extension crates to
+  `LOAD` their own locally-built (unsigned) `.duckdb_extension` artifact for
+  integration testing. (Thanks @killzoner.)
+
+### Changed
+
+- `duckdb` is now a purely optional dependency, activated only by `bundled-test`
+  / `bundled-test-prebuilt`. It is no longer a dev-dependency, and there is no
+  default `bundled` feature. As a result, a plain `cargo test` — and every
+  downstream consumer's `Cargo.lock` — no longer pulls the DuckDB + arrow tree,
+  and the default test build no longer compiles DuckDB.
+
+### Security
+
+- **`tar` 0.4.45 → 0.4.46** in both the root and example lockfiles, resolving
+  **GHSA-3pv8-6f4r-ffg2** ("PAX header desynchronization", Moderate). `tar` is a
+  `libduckdb-sys` build-dependency, so it appears in both `Cargo.lock` files and
+  raised one Dependabot alert each — the two moderate alerts reported on `main`.
+  This advisory is published in the GitHub Advisory Database (GHSA) but not the
+  RustSec database, so `cargo deny` did not flag it; the new OSV scan below closes
+  that gap.
+- Bumped `cc` 1.2.62 → 1.2.63 (which moves `shlex` 1.3.0 → 2.0.1) and refreshed
+  the `codecov/codecov-action` pin to v6.0.1.
+
+### CI / tooling
+
+- Added an **OSV / GHSA advisory scan** to CI (`osv-scanner`, pinned to v2.3.8 via
+  a checksum-verified binary) covering both `Cargo.lock` files. `cargo deny`
+  consults only the RustSec database; OSV.dev aggregates GHSA **and** RustSec, so
+  GHSA-only advisories (such as the `tar` one above) now fail CI alongside the
+  existing cargo-deny gate.
 
 ## [0.13.0] — 2026-05-24
 
@@ -688,7 +768,10 @@ the workspace `Cargo.lock` and `examples/hello-ext/Cargo.lock`.
 
 ---
 
-[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/tomtom215/quack-rs/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/tomtom215/quack-rs/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/tomtom215/quack-rs/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/tomtom215/quack-rs/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/tomtom215/quack-rs/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/tomtom215/quack-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/tomtom215/quack-rs/compare/v0.10.0...v0.11.0

--- a/book/src/reference/pitfalls.md
+++ b/book/src/reference/pitfalls.md
@@ -271,15 +271,18 @@ often ignored. When it returns `DuckDBError`, the function set is not registered
 
 ## P7: `duckdb_string_t` format is undocumented
 
-**Status**: Handled by `VectorReader::read_str` and `DuckStringView`.
+**Status**: Handled by `VectorReader::read_str`, `VectorReader::read_blob`, and
+`DuckStringView`.
 
-**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes.
+**Symptom**: VARCHAR reading produces garbage, empty strings, or crashes; BLOB
+reading silently drops bytes that are not valid UTF-8.
 
 **Root cause**: DuckDB stores strings in a 16-byte struct with two formats
 (inline ≤ 12 bytes, pointer > 12 bytes) that are not documented in
 `libduckdb-sys`.
 
-**Fix**: Use `VectorReader::read_str(row)`. See
+**Fix**: Use `VectorReader::read_str(row)` for UTF-8 text and
+`VectorReader::read_blob(row)` for arbitrary binary data. See
 [NULL Handling & Strings](../data/nulls-and-strings.md).
 
 ---

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cc",
  "libduckdb-sys",

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -495,9 +495,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10503.1"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -841,7 +841,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -977,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/hello-ext/Cargo.lock
+++ b/examples/hello-ext/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 //!    or improved safety. When in doubt, prefer simplicity.
 //! 2. **No panics across FFI**: `unwrap()` is forbidden in FFI callbacks and entry points.
 //! 3. **Bounded version range**: `libduckdb-sys` uses `>=1.4.4, <2` to support `DuckDB` 1.4.x
-//!    and 1.5.x (through v1.5.3) while preventing silent adoption of breaking changes in
+//!    and 1.5.x (through v1.5.4) while preventing silent adoption of breaking changes in
 //!    future major releases.
 //! 4. **Testable business logic**: state structs have zero FFI dependencies.
 //!
@@ -178,10 +178,10 @@ pub mod table_description;
 /// The `DuckDB` C API version string required by [`duckdb_rs_extension_api_init`][libduckdb_sys::duckdb_rs_extension_api_init].
 ///
 /// This constant corresponds to every `DuckDB` release from v1.4.x through
-/// v1.5.3: the C extension API version has remained `v1.2.0` across all of them
-/// (it did **not** change in the v1.5.1, v1.5.2, or v1.5.3 patch releases). If
-/// you are targeting a different `DuckDB` release, consult the `DuckDB` changelog
-/// for the C API version.
+/// v1.5.4: the C extension API version has remained `v1.2.0` across all of them
+/// (it did **not** change in the v1.5.1, v1.5.2, v1.5.3, or v1.5.4 patch
+/// releases). If you are targeting a different `DuckDB` release, consult the
+/// `DuckDB` changelog for the C API version.
 ///
 /// # Pitfall P2: C API version ≠ `DuckDB` release version
 ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -27,6 +27,8 @@
 //! }
 //! ```
 
+mod blob;
+
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
@@ -60,6 +62,7 @@ use crate::error::ExtensionError;
 ///
 /// Use typed accessors to extract the underlying data:
 /// - [`as_str`][Value::as_str] — VARCHAR → `String`
+/// - [`as_blob`][Value::as_blob] — BLOB → `Vec<u8>`
 /// - [`as_i32`][Value::as_i32] — INTEGER → `i32`
 /// - [`as_i64`][Value::as_i64] — BIGINT → `i64`
 /// - [`as_f32`][Value::as_f32] — FLOAT → `f32`

--- a/src/value/blob.rs
+++ b/src/value/blob.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Tom F. <https://github.com/tomtom215/>
+// My way of giving something small back to the open source community
+// and encouraging more Rust development!
+
+use libduckdb_sys::{duckdb_blob, duckdb_free, duckdb_get_blob};
+
+use super::Value;
+use crate::error::ExtensionError;
+
+fn blob_size(blob: &duckdb_blob) -> Result<Option<usize>, ExtensionError> {
+    if blob.data.is_null() {
+        return if blob.size == 0 {
+            Ok(None)
+        } else {
+            Err(ExtensionError::new("duckdb_get_blob returned null data"))
+        };
+    }
+    usize::try_from(blob.size)
+        .map(Some)
+        .map_err(|_| ExtensionError::new("duckdb_get_blob returned an unsupported blob size"))
+}
+
+#[mutants::skip] // DuckDB allocator effects are not observable from safe Rust tests.
+unsafe fn free_blob_data(data: *mut core::ffi::c_void) {
+    if !data.is_null() {
+        unsafe { duckdb_free(data) };
+    }
+}
+
+impl Value {
+    /// Extracts the value as an owned `Vec<u8>` (`BLOB`).
+    ///
+    /// `DuckDB` allocates the blob's backing buffer; this method copies it into
+    /// an owned `Vec<u8>` and frees the original with `duckdb_free`. The bytes
+    /// are copied without UTF-8 validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExtensionError` if the value handle is null, `duckdb_get_blob`
+    /// returns a null data pointer for a non-empty blob, or the blob size cannot
+    /// be represented by `usize` on the current platform.
+    pub fn as_blob(&self) -> Result<Vec<u8>, ExtensionError> {
+        if self.raw.is_null() {
+            return Err(ExtensionError::new("Value is null"));
+        }
+        // SAFETY: self.raw is a valid duckdb_value per constructor contract.
+        let blob: duckdb_blob = unsafe { duckdb_get_blob(self.raw) };
+        let size = match blob_size(&blob) {
+            Ok(None) => return Ok(Vec::new()),
+            Ok(Some(size)) => size,
+            Err(error) => {
+                // SAFETY: non-null blob data was allocated by DuckDB. The
+                // helper also accepts null for the invalid-pointer error path.
+                unsafe { free_blob_data(blob.data) };
+                return Err(error);
+            }
+        };
+        // SAFETY: blob.data is a DuckDB-allocated buffer of exactly `blob.size`
+        // bytes, valid until we free it below.
+        let slice = unsafe { std::slice::from_raw_parts(blob.data.cast::<u8>(), size) };
+        let out = slice.to_vec();
+        // SAFETY: blob.data was allocated by DuckDB and must be freed with duckdb_free.
+        unsafe { free_blob_data(blob.data) };
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_size_null_empty_blob_is_valid() {
+        let blob = duckdb_blob {
+            data: std::ptr::null_mut(),
+            size: 0,
+        };
+        assert!(matches!(blob_size(&blob), Ok(None)));
+    }
+
+    #[test]
+    fn blob_size_null_non_empty_blob_is_invalid() {
+        let blob = duckdb_blob {
+            data: std::ptr::null_mut(),
+            size: 1,
+        };
+        assert!(blob_size(&blob).is_err());
+    }
+
+    #[test]
+    fn null_value_as_blob_returns_error() {
+        let value = unsafe { Value::from_raw(std::ptr::null_mut()) };
+        assert!(value.as_blob().is_err());
+    }
+
+    #[cfg(feature = "_duckdb-testing")]
+    #[test]
+    fn blob_value_non_utf8_bytes_round_trip() {
+        let _db = crate::testing::InMemoryDb::open().expect("should initialize DuckDB");
+        let payload = [
+            0x80u8, 0xF0, 0x01, 0x42, 0xFF, 0x00, 0xFE, 0x7F, 0xAA, 0x55, 0xC0, 0xAF, 0x90,
+        ];
+        let len = u64::try_from(payload.len()).expect("test payload length fits in u64");
+        // SAFETY: payload points to `len` readable bytes for the duration of the call.
+        let raw = unsafe { libduckdb_sys::duckdb_create_blob(payload.as_ptr(), len) };
+        // SAFETY: duckdb_create_blob returns an owned value handle.
+        let value = unsafe { Value::from_raw(raw) };
+
+        assert_eq!(value.as_blob().expect("blob should be readable"), payload);
+    }
+
+    #[cfg(feature = "_duckdb-testing")]
+    #[test]
+    fn blob_value_empty_bytes_round_trip() {
+        let _db = crate::testing::InMemoryDb::open().expect("should initialize DuckDB");
+        let payload = [];
+        // SAFETY: payload is readable for zero bytes for the duration of the call.
+        let raw = unsafe { libduckdb_sys::duckdb_create_blob(payload.as_ptr(), 0) };
+        // SAFETY: duckdb_create_blob returns an owned value handle.
+        let value = unsafe { Value::from_raw(raw) };
+
+        assert!(value.as_blob().expect("blob should be readable").is_empty());
+    }
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -28,7 +28,7 @@ pub mod validity;
 pub mod writer;
 
 pub use reader::VectorReader;
-pub use string::{read_duck_string, DuckStringView};
+pub use string::{read_duck_blob, read_duck_string, DuckStringView};
 pub use struct_reader::StructReader;
 pub use struct_writer::StructWriter;
 pub use validity::ValidityBitmap;

--- a/src/vector/reader.rs
+++ b/src/vector/reader.rs
@@ -300,6 +300,8 @@ impl VectorReader {
     /// VARCHAR (inline for ≤12 bytes, pointer for larger values). The returned
     /// slice borrows from the vector's data buffer.
     ///
+    /// The bytes are returned without UTF-8 validation.
+    ///
     /// # Safety
     ///
     /// - `idx` must be less than `self.row_count()`.
@@ -307,7 +309,7 @@ impl VectorReader {
     /// - The pointed-to memory must be valid for the lifetime of the returned slice.
     pub unsafe fn read_blob(&self, idx: usize) -> &[u8] {
         // SAFETY: BLOB uses the same duckdb_string_t layout as VARCHAR.
-        unsafe { crate::vector::string::read_duck_string(self.data, idx).as_bytes() }
+        unsafe { crate::vector::string::read_duck_blob(self.data, idx) }
     }
 
     /// Reads a `UUID` value at row `idx` as an `i128`.

--- a/src/vector/string.rs
+++ b/src/vector/string.rs
@@ -3,7 +3,7 @@
 // My way of giving something small back to the open source community
 // and encouraging more Rust development!
 
-//! `DuckDB` `VARCHAR` (`duckdb_string_t`) reading utilities.
+//! `DuckDB` `VARCHAR` and `BLOB` (`duckdb_string_t`) reading utilities.
 //!
 //! # Pitfall P7: Undocumented `duckdb_string_t` format
 //!
@@ -184,6 +184,28 @@ pub unsafe fn read_duck_string<'a>(data: *const u8, idx: usize) -> &'a str {
     DuckStringView::from_bytes(raw_bytes).as_str().unwrap_or("")
 }
 
+/// Reads a `DuckDB` `BLOB` value at the given row index.
+///
+/// Returns the raw bytes without UTF-8 validation, or an empty slice if a
+/// pointer-format value contains a null pointer. `BLOB` and `VARCHAR` share the
+/// same `duckdb_string_t` layout (inline for ≤ 12 bytes, pointer otherwise).
+///
+/// # Safety
+///
+/// - `data` must point at a `DuckDB` BLOB (or VARCHAR) vector's data buffer.
+/// - `idx` must be within bounds of the vector.
+/// - For pointer-format blobs, the heap data must be valid for the lifetime of
+///   the returned slice.
+pub unsafe fn read_duck_blob<'a>(data: *const u8, idx: usize) -> &'a [u8] {
+    // SAFETY: each duckdb_string_t is exactly DUCK_STRING_SIZE bytes.
+    let str_ptr = unsafe { data.add(idx * DUCK_STRING_SIZE) };
+    let raw_bytes: &'a [u8; DUCK_STRING_SIZE] =
+        unsafe { &*str_ptr.cast::<[u8; DUCK_STRING_SIZE]>() };
+    DuckStringView::from_bytes(raw_bytes)
+        .as_bytes_unsafe()
+        .unwrap_or(&[])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +251,33 @@ mod tests {
     }
 
     #[test]
+    fn read_duck_blob_preserves_non_utf8_inline_bytes() {
+        let payload = [0x80u8, 0xF0, 0x01, 0x42];
+        let mut bytes = [0u8; 16];
+        let len = u32::try_from(payload.len()).unwrap_or(u32::MAX);
+        bytes[..4].copy_from_slice(&len.to_le_bytes());
+        bytes[4..4 + payload.len()].copy_from_slice(&payload);
+
+        assert_eq!(unsafe { read_duck_blob(bytes.as_ptr(), 0) }, &payload);
+        assert_eq!(unsafe { read_duck_string(bytes.as_ptr(), 0) }, "");
+    }
+
+    #[test]
+    fn read_duck_blob_preserves_non_utf8_pointer_bytes() {
+        let payload = [
+            0x80u8, 0xF0, 0x01, 0x42, 0xFF, 0x00, 0xFE, 0x7F, 0xAA, 0x55, 0xC0, 0xAF, 0x90,
+        ];
+        let mut bytes = [0u8; 16];
+        let len = u32::try_from(payload.len()).unwrap_or(u32::MAX);
+        bytes[..4].copy_from_slice(&len.to_le_bytes());
+        bytes[4..8].copy_from_slice(&payload[..4]);
+        let ptr = payload.as_ptr() as usize as u64;
+        bytes[8..16].copy_from_slice(&ptr.to_le_bytes());
+
+        assert_eq!(unsafe { read_duck_blob(bytes.as_ptr(), 0) }, &payload);
+    }
+
+    #[test]
     fn pointer_format_string() {
         let long_str = "this is a longer string that exceeds 12 bytes";
         let len = long_str.len();
@@ -262,6 +311,7 @@ mod tests {
         let view = DuckStringView::from_bytes(&bytes);
         // Null pointer for long string should return None
         assert!(view.as_str().is_none());
+        assert!(unsafe { read_duck_blob(bytes.as_ptr(), 0) }.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

## Summary

This PR consolidates the currently-open community and Dependabot contributions, fixes two newly-published security advisories that were failing CI on `main`, brings the repo's DuckDB to the latest **1.5.4** bugfix release, and cuts the **v0.15.0** release. Every change was adversarially reviewed, and the fully consolidated branch is **green in CI (all 27 jobs)**. Commit authorship for **@adonm** (PR #104) and Dependabot is preserved.

| Area | Change |
|------|--------|
| **Community — PR #104 (@adonm)** | **Bug fix:** `VectorReader::read_blob` routed through the VARCHAR reader, so non-UTF-8 `BLOB` bytes were silently returned as an *empty* slice — now reads raw bytes via `read_duck_blob`. **Adds** `Value::as_blob()` (owned `Vec<u8>` extraction with DuckDB alloc cleanup). |
| **Security** | `crossbeam-epoch` 0.9.18 → 0.9.20 (**RUSTSEC-2026-0204**) and `quinn-proto` 0.11.14 → 0.11.15 (**RUSTSEC-2026-0185**, CVSS 7.5). Both pre-existing on `main`; they were failing the cargo-deny and OSV/GHSA gates. Lockfile-only, within existing ranges. |
| **DuckDB** | Dev/CI bump to **1.5.4** (`libduckdb-sys`/`duckdb` → 1.10504.0). C extension API is unchanged at `v1.2.0` (verified from `duckdb_extension.h`), public dep range `>=1.4.4, <2` untouched → downstream consumers unaffected. This also **fixed the Windows `bundled-test` MSVC compile failure**. |
| **Dependabot** | SHA-pinned Actions, each new SHA verified against its upstream tag: `actions/checkout` v7 (#103), `codecov/codecov-action` v7 (#99), `actions/cache` v6.1 (#105), `actions/attest-build-provenance` v4.1.1 (#106). `cc` 1.2.64 (#101); example `libduckdb-sys` 1.5.4 (#102). |
| **Release** | 0.14.0 → **0.15.0** (MINOR — new public API per the RELEASING.md semver policy). @adonm credited in the changelog; book changelog re-synced (it had drifted a release behind); SECURITY.md supported-versions updated. |

## Type of change

- [x] Bug fix (non-breaking, fixes a specific issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing API changes or removals)
- [x] Documentation update
- [x] CI / tooling / dependency update
- [ ] Refactoring (no behaviour change)

## Checklist

### Code quality
- [x] `cargo test --all-targets` passes — including `--features bundled-test,duckdb-1-5-3` compiling DuckDB 1.5.4 from source and running the real-DuckDB FFI round-trip tests (538 + 64 tests, 0 failed)
- [x] `cargo clippy --all-targets -- -D warnings` passes (default and `duckdb-1-5-3`)
- [x] `cargo fmt` applied (no diff)
- [x] `cargo doc --no-deps` builds without warnings
- [x] All `unsafe` blocks have a `// SAFETY:` comment (PR #104)
- [x] SPDX header on every new file (`src/value/blob.rs`)
- [ ] No file exceeds 500 lines — `src/value/blob.rs` is 125 lines; `src/value.rs` remains >500 as it already was on `main` (PR #104 adds only 3 lines to it)

### Testing
- [x] New code has tests — inline / pointer / null-pointer unit tests for `read_duck_blob`, plus real-DuckDB round-trip tests for `Value::as_blob` (non-UTF-8 and empty payloads)
- [x] `cargo mutants` — the `mutants` CI job runs this on the PR; PR #104 reported 7/7 caught locally (not independently re-run here)

### Documentation
- [x] Public API changes are documented in rustdoc
- [x] `CHANGELOG.md` updated — promoted to `[0.15.0]` for this release, with the `(Thanks @adonm.)` credit
- [x] Book (`book/src/`) updated — PR #104 updated the data/reference pages; the book changelog mirror is re-synced
- [x] New FFI pitfall → PR #104 extended `LESSONS.md` and `book/src/reference/pitfalls.md` (P7: `duckdb_string_t` BLOB handling)

### Safety (changes touching `unsafe`)
- [x] No new panics introduced in FFI callback paths
- [x] No new paths that could cross the FFI boundary with an unwinding panic
- [x] `#[deny(unsafe_op_in_unsafe_fn)]` remains satisfied

---

### Reviewer notes
- **SECURITY.md**: I applied the table's existing "two-newest-supported" pattern (0.15.x + 0.14.x supported; 0.13.x/0.12.x → end-of-life). Adjust if your support policy differs.
- **Book changelog**: it had drifted a release behind `main` (missing the entire `[0.14.0]` section and stale compare links); this PR backfills `[0.14.0]` alongside the new `[0.15.0]`.
- **Left as-is (pre-existing, outside the release runbook):** `CITATION.cff` (0.10.0) and the README install snippet (`quack-rs = "0.13"`) are stale — flagging for a future docs pass rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164uVVBhnwJjhBgXuKmTrMz

---
_Generated by [Claude Code](https://claude.ai/code/session_0164uVVBhnwJjhBgXuKmTrMz)_